### PR TITLE
Implements Scannable for table and list of tables

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -47,6 +47,14 @@ type TableDef struct {
     columns map[string]*ColumnDef
 }
 
+func (t *TableDef) Size() int {
+    return len(t.name)
+}
+
+func (t *TableDef) Scan(b []byte) int {
+    return copy(b, t.name)
+}
+
 func (t *TableDef) Column(colName string) *ColumnDef {
     return t.columns[colName]
 }

--- a/table.go
+++ b/table.go
@@ -23,3 +23,30 @@ func (t *Table) Scan(b []byte) int {
     }
     return written
 }
+
+type TableList struct {
+    tables []*Table
+}
+
+func (tl *TableList) Size() int {
+    size := 0
+    ntables := len(tl.tables)
+    for _, t := range tl.tables {
+        size += t.Size()
+    }
+    size += (SYM_COMMA_WS_LEN * (ntables - 1))  // Add in the commas
+    return size
+}
+
+func (tl *TableList) Scan(b []byte) int {
+    ntables := len(tl.tables)
+    written := 0
+    for x, t := range tl.tables {
+        written += t.Scan(b[written:])
+        if x != (ntables - 1) {
+            copy(b[written:], SYM_COMMA_WS)
+            written += SYM_COMMA_WS_LEN
+        }
+    }
+    return written
+}

--- a/table.go
+++ b/table.go
@@ -1,0 +1,25 @@
+package sqlb
+
+type Table struct {
+    alias string
+    def *TableDef
+}
+
+func (t *Table) Size() int {
+    size := t.def.Size()
+    if t.alias != "" {
+        size += SYM_AS_LEN + len(t.alias)
+    }
+    return size
+}
+
+func (t *Table) Scan(b []byte) int {
+    written := t.def.Scan(b)
+    if t.alias != "" {
+        copy(b[written:], []byte(SYM_AS))
+        written += SYM_AS_LEN
+        nalias := copy(b[written:], []byte(t.alias))
+        written += nalias
+    }
+    return written
+}

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,56 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestTable(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    t1 := &Table{
+        def: td,
+    }
+
+    exp := "users"
+    expLen := len(exp)
+    s := t1.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written := t1.Scan(b)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}
+
+func TestTableAlias(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    t1 := &Table{
+        def: td,
+        alias: "u",
+    }
+
+    exp := "users AS u"
+    expLen := len(exp)
+    s := t1.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written := t1.Scan(b)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}

--- a/table_test.go
+++ b/table_test.go
@@ -54,3 +54,64 @@ func TestTableAlias(t *testing.T) {
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
 }
+
+func TestTableListSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    t1 := &Table{
+        def: td,
+    }
+
+    tl := &TableList{tables: []*Table{t1}}
+
+    exp := "users"
+    expLen := len(exp)
+    s := tl.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written := tl.Scan(b)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}
+
+func TestTableListMulti(t *testing.T) {
+    assert := assert.New(t)
+
+    td1 := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    td2 := &TableDef{
+        name: "articles",
+        schema: "test",
+    }
+
+    t1 := &Table{
+        def: td1,
+    }
+
+    t2 := &Table{
+        def: td2,
+    }
+
+    tl := &TableList{tables: []*Table{t1, t2}}
+
+    exp := "users, articles"
+    expLen := len(exp)
+    s := tl.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written := tl.Scan(b)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}


### PR DESCRIPTION
Adds new Table and TableList structs that wrap the TableDef struct and an array of pointers to Table structs. These new structs implement the Scannable interface's Scan() and Size() methods.

Issue #3