### PR TITLE
Implement Scannable for SELECT ... FROM

### DIFF
--- a/column.go
+++ b/column.go
@@ -16,9 +16,9 @@ func (c *Column) Size() int {
 func (c *Column) Scan(b []byte) int {
     written := c.def.Scan(b)
     if c.alias != "" {
-        copy(b[written:], []byte(SYM_AS))
+        copy(b[written:], SYM_AS)
         written += SYM_AS_LEN
-        nalias := copy(b[written:], []byte(c.alias))
+        nalias := copy(b[written:], c.alias)
         written += nalias
     }
     return written
@@ -47,7 +47,7 @@ func (cl *ColumnList) Size() int {
     for _, c := range cl.columns {
         size += c.Size()
     }
-    size += (SYM_COMMA_WS_LEN * (ncols - 1))  // Add in the commas
+    size += (SYM_COMMA_WS_LEN * (ncols - 1))
     return size
 }
 

--- a/column.go
+++ b/column.go
@@ -37,6 +37,10 @@ type ColumnList struct {
     columns []*Column
 }
 
+func (cl *ColumnList) Columns() []*Column {
+    return cl.columns
+}
+
 func (cl *ColumnList) Size() int {
     size := 0
     ncols := len(cl.columns)

--- a/column_test.go
+++ b/column_test.go
@@ -137,3 +137,21 @@ func TestColumnListMulti(t *testing.T) {
 
     assert.Equal(cl.columns, cl.Columns())
 }
+
+func TestColumnAs(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := cd.As("n")
+    assert.Equal("n", c.alias)
+    assert.Equal(cd, c.def)
+}

--- a/column_test.go
+++ b/column_test.go
@@ -134,4 +134,6 @@ func TestColumnListMulti(t *testing.T) {
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
+
+    assert.Equal(cl.columns, cl.Columns())
 }

--- a/meta.go
+++ b/meta.go
@@ -41,6 +41,11 @@ func (c *ColumnDef) Scan(b []byte) int {
     return copy(b, c.name)
 }
 
+// Generate an aliased Column from a ColumnDef
+func (c *ColumnDef) As(alias string) *Column {
+    return &Column{def: c, alias: alias}
+}
+
 type TableDef struct {
     name string
     schema string
@@ -53,6 +58,11 @@ func (t *TableDef) Size() int {
 
 func (t *TableDef) Scan(b []byte) int {
     return copy(b, t.name)
+}
+
+// Generate an aliased Table from a TableDef
+func (t *TableDef) As(alias string) *Table {
+    return &Table{def: t, alias: alias}
 }
 
 func (t *TableDef) Column(colName string) *ColumnDef {

--- a/meta.go
+++ b/meta.go
@@ -49,7 +49,7 @@ func (c *ColumnDef) As(alias string) *Column {
 type TableDef struct {
     name string
     schema string
-    columns map[string]*ColumnDef
+    columns []*ColumnDef
 }
 
 func (t *TableDef) Size() int {
@@ -66,17 +66,16 @@ func (t *TableDef) As(alias string) *Table {
 }
 
 func (t *TableDef) Column(colName string) *ColumnDef {
-    return t.columns[colName]
+    for _, cdef := range t.columns {
+        if cdef.name == colName {
+            return cdef
+        }
+    }
+    return nil
 }
 
 func (t *TableDef) ColumnDefs() []*ColumnDef {
-    res := make([]*ColumnDef, len(t.columns))
-    x := 0
-    for _, def := range t.columns {
-        res[x] = def
-        x++
-    }
-    return res
+    return t.columns
 }
 
 type Meta struct {
@@ -131,10 +130,10 @@ func fillTableColumnDefs(db *sql.DB, schemaName string, tables *map[string]*Tabl
         }
         table = (*tables)[tname]
         if table.columns == nil {
-            table.columns = make(map[string]*ColumnDef, 0)
+            table.columns = make([]*ColumnDef, 0)
         }
         col := &ColumnDef{table: table, name: cname}
-        table.columns[cname] = col
+        table.columns = append(table.columns, col)
     }
     return nil
 }

--- a/meta.go
+++ b/meta.go
@@ -59,6 +59,16 @@ func (t *TableDef) Column(colName string) *ColumnDef {
     return t.columns[colName]
 }
 
+func (t *TableDef) ColumnDefs() []*ColumnDef {
+    res := make([]*ColumnDef, len(t.columns))
+    x := 0
+    for _, def := range t.columns {
+        res[x] = def
+        x++
+    }
+    return res
+}
+
 type Meta struct {
     db *sql.DB
     tables map[string]*TableDef

--- a/select.go
+++ b/select.go
@@ -1,0 +1,108 @@
+package sqlb
+
+type Selectable struct {
+    alias string
+    projected *ColumnList
+    subjects []Scannable
+}
+
+func (s *Selectable) Alias(alias string) {
+    s.alias = alias
+}
+
+func (s *Selectable) As(alias string) *Selectable {
+    s.Alias(alias)
+    return s
+}
+
+func (s *Selectable) Size() int {
+    size := SYM_SELECT_LEN + SYM_FROM_LEN
+    size += s.projected.Size()
+    for _, subj := range s.subjects {
+        size += subj.Size()
+    }
+    if s.alias != "" {
+        size += SYM_AS_LEN + len(s.alias)
+    }
+    return size
+}
+
+func (s *Selectable) Scan(b []byte) int {
+    idx := 0
+    idx += copy(b[idx:], SYM_SELECT)
+    idx += s.projected.Scan(b[idx:])
+    idx += copy(b[idx:], SYM_FROM)
+    for _, subj := range s.subjects {
+        idx += subj.Scan(b[idx:])
+    }
+    if s.alias != "" {
+        idx += copy(b[idx:], SYM_AS)
+        idx += copy(b[idx:], s.alias)
+    }
+    return idx
+}
+
+func (s *Selectable) String() string {
+    size := s.Size()
+    b := make([]byte, size)
+    s.Scan(b)
+    return string(b)
+}
+
+func Select(items ...Scannable) *Selectable {
+    // TODO(jaypipes): Make the memory allocation more efficient below by
+    // looping through the elements and determining the number of Column struct
+    // pointers to allocate instead of just making an empty array of Column
+    // pointers.
+    res := &Selectable{
+        projected: &ColumnList{},
+    }
+
+    subjSet := make(map[Scannable]bool, 0)
+
+    // For each scannable item we're received in the call, check what concrete
+    // type they are and, depending on which type they are, either add them to
+    // the returned Selectable's projected ColumnList or query the underlying
+    // table metadata to generate a list of all columns in that table.
+    for _, item := range items {
+        switch item.(type) {
+            case *Column:
+                v := item.(*Column)
+                res.projected.columns = append(res.projected.columns, v)
+                subjSet[v.def.table] = true
+            case *ColumnList:
+                v := item.(*ColumnList)
+                for _, c := range v.Columns() {
+                    res.projected.columns = append(res.projected.columns, c)
+                    subjSet[c.def.table] = true
+                }
+            case *Table:
+                v := item.(*Table)
+                for _, c := range v.Columns() {
+                    res.projected.columns = append(res.projected.columns, c)
+                }
+                subjSet[v] = true
+            case *TableDef:
+                v := item.(*TableDef)
+                for _, cd := range v.ColumnDefs() {
+                    c := &Column{def: cd}
+                    res.projected.columns = append(res.projected.columns, c)
+                }
+                t := &Table{def: v}
+                subjSet[t] = true
+            case *ColumnDef:
+                v := item.(*ColumnDef)
+                c := &Column{def: v}
+                res.projected.columns = append(res.projected.columns, c)
+                subjSet[v.table] = true
+        }
+    }
+    subjects := make([]Scannable, len(subjSet))
+    x := 0
+    for scannable, _ := range subjSet {
+        subjects[x] = scannable
+        x++
+    }
+    res.subjects = subjects
+    return res
+}

--- a/select_test.go
+++ b/select_test.go
@@ -1,0 +1,150 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestSelectSingleColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    sel := Select(c)
+
+    exp := "SELECT name FROM users"
+    expLen := len(exp)
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectMultiColumnsSingleTable(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c1 := &Column{
+        def: cd1,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    c2 := &Column{
+        def: cd2,
+    }
+
+    sel := Select(c1, c2)
+
+    exp := "SELECT name, email FROM users"
+    expLen := len(exp)
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectFromColumnDef(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd)
+
+    exp := "SELECT name FROM users"
+    expLen := len(exp)
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectFromColumnDefAndColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    c2 := &Column{
+        def: cd2,
+    }
+
+    sel := Select(cd1, c2)
+
+    exp := "SELECT name, email FROM users"
+    expLen := len(exp)
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectFromTableDef(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cdefs := []*ColumnDef{
+        &ColumnDef{
+            name: "name",
+            table: td,
+        },
+        &ColumnDef{
+            name: "email",
+            table: td,
+        },
+    }
+    td.columns = cdefs
+
+    sel := Select(td)
+
+    exp := "SELECT name, email FROM users"
+    expLen := len(exp)
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(exp, sel.String())
+}

--- a/table.go
+++ b/table.go
@@ -26,9 +26,9 @@ func (t *Table) Size() int {
 func (t *Table) Scan(b []byte) int {
     written := t.def.Scan(b)
     if t.alias != "" {
-        copy(b[written:], []byte(SYM_AS))
+        copy(b[written:], SYM_AS)
         written += SYM_AS_LEN
-        nalias := copy(b[written:], []byte(t.alias))
+        nalias := copy(b[written:], t.alias)
         written += nalias
     }
     return written

--- a/table.go
+++ b/table.go
@@ -5,6 +5,16 @@ type Table struct {
     def *TableDef
 }
 
+func (t *Table) Columns() []*Column {
+    cdefs := t.def.ColumnDefs()
+    ncols := len(cdefs)
+    cols := make([]*Column, ncols)
+    for x := 0; x < ncols; x++ {
+        cols[x] = &Column{def: cdefs[x]}
+    }
+    return cols
+}
+
 func (t *Table) Size() int {
     size := t.def.Size()
     if t.alias != "" {

--- a/table_test.go
+++ b/table_test.go
@@ -115,3 +115,59 @@ func TestTableListMulti(t *testing.T) {
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
 }
+
+func TestTableColumnDefs(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cdefs := map[string]*ColumnDef{
+        "id": &ColumnDef{
+            name: "id",
+            table: td,
+        },
+        "email": &ColumnDef{
+            name: "email",
+            table: td,
+        },
+    }
+    td.columns = cdefs
+
+    defs := td.ColumnDefs()
+
+    assert.Equal(2, len(defs))
+    for _, def := range defs {
+        assert.Equal(td, def.table)
+    }
+}
+
+func TestTableColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cdefs := map[string]*ColumnDef{
+        "id": &ColumnDef{
+            name: "id",
+            table: td,
+        },
+        "email": &ColumnDef{
+            name: "email",
+            table: td,
+        },
+    }
+    td.columns = cdefs
+
+    defs := td.ColumnDefs()
+
+    assert.Equal(2, len(defs))
+    for _, def := range defs {
+        assert.Equal(td, def.table)
+    }
+}

--- a/table_test.go
+++ b/table_test.go
@@ -124,12 +124,12 @@ func TestTableColumnDefs(t *testing.T) {
         schema: "test",
     }
 
-    cdefs := map[string]*ColumnDef{
-        "id": &ColumnDef{
+    cdefs := []*ColumnDef{
+         &ColumnDef{
             name: "id",
             table: td,
         },
-        "email": &ColumnDef{
+        &ColumnDef{
             name: "email",
             table: td,
         },
@@ -142,6 +142,10 @@ func TestTableColumnDefs(t *testing.T) {
     for _, def := range defs {
         assert.Equal(td, def.table)
     }
+
+    // Check stable order of insertion from above...
+    assert.Equal(defs[0].name, "id")
+    assert.Equal(defs[1].name, "email")
 }
 
 func TestTableColumn(t *testing.T) {
@@ -152,24 +156,26 @@ func TestTableColumn(t *testing.T) {
         schema: "test",
     }
 
-    cdefs := map[string]*ColumnDef{
-        "id": &ColumnDef{
+    cdefs := []*ColumnDef{
+        &ColumnDef{
             name: "id",
             table: td,
         },
-        "email": &ColumnDef{
+        &ColumnDef{
             name: "email",
             table: td,
         },
     }
     td.columns = cdefs
 
-    defs := td.ColumnDefs()
+    c := td.Column("email")
 
-    assert.Equal(2, len(defs))
-    for _, def := range defs {
-        assert.Equal(td, def.table)
-    }
+    assert.Equal(td, c.table)
+    assert.Equal("email", c.name)
+
+    // Check an unknown column name returns nil
+    unknown := td.Column("unknown")
+    assert.Nil(unknown)
 }
 
 func TestTableAs(t *testing.T) {

--- a/table_test.go
+++ b/table_test.go
@@ -171,3 +171,16 @@ func TestTableColumn(t *testing.T) {
         assert.Equal(td, def.table)
     }
 }
+
+func TestTableAs(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    t1 := td.As("u")
+    assert.Equal("u", t1.alias)
+    assert.Equal(td, t1.def)
+}


### PR DESCRIPTION
Adds a new `sqlb.Select()` function that accepts a list of Scannable
items and returns a `sqlb.Selectable` struct pointer. This
`sqlb.Selectable` itself implements Scannable, making it a reusable
component of the `sqlb` library.

`sqlb.Select()` analyzes the concrete types of the supplied list of
Scannable items and appends projected columns and subjects (elements of
the SQL FROM clause to itself). This means that we can call
`sqlb.Select()` with a Column, ColumnList, ColumnDef, Table, or
TableDef.

Closes Issue #6