### PR TITLE
Support for expressions and operators

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -29,7 +29,7 @@ func TestColumn(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := c.Scan(b)
+    written, _ := c.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -59,7 +59,7 @@ func TestColumnAlias(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := c.Scan(b)
+    written, _ := c.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -90,7 +90,7 @@ func TestColumnListSingle(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := cl.Scan(b)
+    written, _ := cl.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -130,7 +130,7 @@ func TestColumnListMulti(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := cl.Scan(b)
+    written, _ := cl.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))

--- a/element.go
+++ b/element.go
@@ -1,0 +1,17 @@
+package sqlb
+
+type Element interface {
+    // Returns the number of bytes that the scannable element would consume as
+    // a SQL string
+    Size() int
+    // Returns the number of interface{} arguments that the element will add to
+    // the slice of interface{} arguments passed to Scan()
+    ArgCount() int
+    // Scan takes two slices -- one for the slice of bytes that the
+    // implementation should copy its string representation to and another for
+    // the slice of interface{} values that the element should add its
+    // arguments to -- and returns two ints, one for the number of bytes that
+    // it copied into the byte slice and another for the number of arguments
+    // copied into the arg slice
+    Scan([]byte, []interface{}) (int, int)
+}

--- a/expression.go
+++ b/expression.go
@@ -1,0 +1,31 @@
+package sqlb
+
+type Op int
+
+const (
+    OP_EQUAL = iota
+    OP_NEQUAL
+)
+
+type Expression struct {
+    op Op
+    left Element
+    right Element
+}
+
+func (o *Expression) ArgCount() int {
+    return o.left.ArgCount() + o.right.ArgCount()
+}
+
+func (o *Expression) Size() int {
+    return len(SYM_OP[o.op]) + o.left.Size() + o.right.Size()
+}
+
+func (o *Expression) Scan(b []byte, args []interface{}) (int, int) {
+    idx, argc := o.left.Scan(b, args)
+    idx += copy(b[idx:], SYM_OP[o.op])
+    bc, ac := o.right.Scan(b[idx:], args)
+    idx += bc
+    argc += ac
+    return idx, argc
+}

--- a/expression.go
+++ b/expression.go
@@ -29,3 +29,21 @@ func (o *Expression) Scan(b []byte, args []interface{}) (int, int) {
     argc += ac
     return idx, argc
 }
+
+func Equal(left interface{}, right interface{}) *Expression {
+    els := toElements(left, right)
+    return &Expression{
+        op: OP_EQUAL,
+        left: els[0],
+        right: els[1],
+    }
+}
+
+func NotEqual(left interface{}, right interface{}) *Expression {
+    els := toElements(left, right)
+    return &Expression{
+        op: OP_NEQUAL,
+        left: els[0],
+        right: els[1],
+    }
+}

--- a/expression_test.go
+++ b/expression_test.go
@@ -80,6 +80,123 @@ func TestExpressionEqual(t *testing.T) {
     assert.Equal(expArgCount, numArgs)
 }
 
+func TestEqualFuncLiteral(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    eq := Equal(c, "foo")
+
+    exp := "name = ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := eq.Size()
+    assert.Equal(expLen, s)
+
+    argc := eq.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs := eq.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestEqualFuncTwoElements(t *testing.T) {
+    assert := assert.New(t)
+
+    users := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    userId := &ColumnDef{
+        name: "id",
+        table: users,
+    }
+
+    c1 := &Column{
+        def: userId,
+    }
+
+    articles := &TableDef{
+        name: "articles",
+        schema: "test",
+    }
+
+    author := &ColumnDef{
+        name: "author",
+        table: articles,
+    }
+
+    c2 := &Column{
+        def: author,
+    }
+
+    eq := Equal(c1, c2)
+
+    exp := "id = author"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := eq.Size()
+    assert.Equal(expLen, s)
+
+    argc := eq.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 0)
+    b := make([]byte, s)
+    written, numArgs := eq.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(0, len(args))
+
+    // Check that if we reverse the order in which the Expression is constructed,
+    // that our Scan() still functions but merely generates the SQL string with
+    // the left and right expression reversed
+
+    erev := Equal(c2, c1)
+
+    exp = "author = id"
+    expLen = len(exp)
+    expArgCount = 0
+
+    s = erev.Size()
+    assert.Equal(expLen, s)
+
+    argc = erev.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, 0)
+    b = make([]byte, s)
+    written, numArgs = erev.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(0, len(args))
+}
+
 func TestExpressionNotEqual(t *testing.T) {
     assert := assert.New(t)
 
@@ -123,4 +240,121 @@ func TestExpressionNotEqual(t *testing.T) {
     assert.Equal(exp, string(b))
     assert.Equal("foo", args[0])
     assert.Equal(expArgCount, numArgs)
+}
+
+func TestNotEqualFuncLiteral(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    eq := NotEqual(c, "foo")
+
+    exp := "name != ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := eq.Size()
+    assert.Equal(expLen, s)
+
+    argc := eq.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs := eq.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestNotEqualFuncTwoElements(t *testing.T) {
+    assert := assert.New(t)
+
+    users := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    userId := &ColumnDef{
+        name: "id",
+        table: users,
+    }
+
+    c1 := &Column{
+        def: userId,
+    }
+
+    articles := &TableDef{
+        name: "articles",
+        schema: "test",
+    }
+
+    author := &ColumnDef{
+        name: "author",
+        table: articles,
+    }
+
+    c2 := &Column{
+        def: author,
+    }
+
+    eq := NotEqual(c1, c2)
+
+    exp := "id != author"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := eq.Size()
+    assert.Equal(expLen, s)
+
+    argc := eq.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 0)
+    b := make([]byte, s)
+    written, numArgs := eq.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(0, len(args))
+
+    // Check that if we reverse the order in which the Expression is constructed,
+    // that our Scan() still functions but merely generates the SQL string with
+    // the left and right expression reversed
+
+    erev := NotEqual(c2, c1)
+
+    exp = "author != id"
+    expLen = len(exp)
+    expArgCount = 0
+
+    s = erev.Size()
+    assert.Equal(expLen, s)
+
+    argc = erev.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, 0)
+    b = make([]byte, s)
+    written, numArgs = erev.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(0, len(args))
 }

--- a/expression_test.go
+++ b/expression_test.go
@@ -1,0 +1,126 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestExpressionEqual(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    lit := &Literal{value: "foo"}
+
+    e := &Expression{
+        op: OP_EQUAL,
+        left: c,
+        right: lit,
+    }
+
+    exp := "name = ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+
+    // Check that if we reverse the order in which the Expression is constructed,
+    // that our Scan() still functions but merely generates the SQL string with
+    // the left and right expression reversed
+
+    erev := &Expression{
+        op: OP_EQUAL,
+        left: lit,
+        right: c,
+    }
+
+    exp = "? = name"
+    expLen = len(exp)
+    expArgCount = 1
+
+    s = erev.Size()
+    assert.Equal(expLen, s)
+
+    argc = erev.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, 1)
+    b = make([]byte, s)
+    written, numArgs = erev.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestExpressionNotEqual(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    lit := &Literal{value: "foo"}
+
+    e := &Expression{
+        op: OP_NEQUAL,
+        left: c,
+        right: lit,
+    }
+
+    exp := "name != ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+}

--- a/literal.go
+++ b/literal.go
@@ -1,0 +1,23 @@
+package sqlb
+
+// A Literal is a concrete struct wrapper around a constant that implements the
+// Scannable interface. Typically, users won't directly construct Literal
+// structs but instead helper functions like sqlb.Equal() will construct a
+// Literal and bind it to the containing Element.
+type Literal struct {
+    value interface{}
+}
+
+func (lit *Literal) ArgCount() int {
+    return 1
+}
+
+func (lit  *Literal) Size() int {
+    return 1  // The literal is always injected as a question mark
+}
+
+func (lit *Literal) Scan(b []byte, args []interface{}) (int, int) {
+    args[0] = lit.value
+    copy(b, SYM_QM)
+    return 1, 1
+}

--- a/literal_test.go
+++ b/literal_test.go
@@ -1,0 +1,32 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestLiteral(t *testing.T) {
+    assert := assert.New(t)
+
+    lit := &Literal{value: "foo"}
+
+    exp := "?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := lit.Size()
+    assert.Equal(expLen, s)
+
+    argc := lit.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs  := lit.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal("foo", args[0])
+    assert.Equal(expArgCount, numArgs)
+}

--- a/meta.go
+++ b/meta.go
@@ -33,12 +33,16 @@ type ColumnDef struct {
     table *TableDef
 }
 
+func (c *ColumnDef) ArgCount() int {
+    return 0
+}
+
 func (c *ColumnDef) Size() int {
     return len(c.name)
 }
 
-func (c *ColumnDef) Scan(b []byte) int {
-    return copy(b, c.name)
+func (c *ColumnDef) Scan(b []byte, args []interface{}) (int, int) {
+    return copy(b, c.name), 0
 }
 
 // Generate an aliased Column from a ColumnDef
@@ -52,12 +56,16 @@ type TableDef struct {
     columns []*ColumnDef
 }
 
+func (t *TableDef) ArgCount() int {
+    return 0
+}
+
 func (t *TableDef) Size() int {
     return len(t.name)
 }
 
-func (t *TableDef) Scan(b []byte) int {
-    return copy(b, t.name)
+func (t *TableDef) Scan(b []byte, args []interface{}) (int, int) {
+    return copy(b, t.name), 0
 }
 
 // Generate an aliased Table from a TableDef

--- a/scannable.go
+++ b/scannable.go
@@ -1,9 +1,0 @@
-package sqlb
-
-type Scannable interface {
-    Size() int
-    // Scan takes a slice of bytes that the implementation should copy its
-    // string representation to and return the number of bytes that it copied
-    // into the byte slice
-    Scan([]byte) int
-}

--- a/symbol.go
+++ b/symbol.go
@@ -11,4 +11,9 @@ var (
     SYM_SELECT_LEN = 7
     SYM_FROM = []byte(" FROM ")
     SYM_FROM_LEN = 6
+
+    SYM_OP = map[Op][]byte{
+        OP_EQUAL: []byte(" = "),
+        OP_NEQUAL: []byte(" != "),
+    }
 )

--- a/symbol.go
+++ b/symbol.go
@@ -1,6 +1,8 @@
 package sqlb
 
 var (
+    SYM_QM = []byte("?")
+    SYM_QM_LEN = 1
     SYM_AS = []byte(" AS ")
     SYM_AS_LEN = 4
     SYM_COMMA_WS = []byte(", ")

--- a/table_test.go
+++ b/table_test.go
@@ -24,7 +24,7 @@ func TestTable(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := t1.Scan(b)
+    written, _ := t1.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -49,7 +49,7 @@ func TestTableAlias(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := t1.Scan(b)
+    written, _ := t1.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -75,7 +75,7 @@ func TestTableListSingle(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := tl.Scan(b)
+    written, _ := tl.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -110,7 +110,7 @@ func TestTableListMulti(t *testing.T) {
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written := tl.Scan(b)
+    written, _ := tl.Scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))

--- a/util.go
+++ b/util.go
@@ -1,0 +1,17 @@
+package sqlb
+
+// Given a slice of interface{} variables, returns a slice of Element members.
+// If any of the interface{} variables are *not* of type Element already, we
+// construct a Literal{} for the variable.
+func toElements(vars ...interface{}) []Element {
+    els := make([]Element, len(vars))
+    for x, v := range vars {
+        switch v.(type) {
+        case Element:
+            els[x] = v.(Element)
+        default:
+            els[x] = &Literal{value: v}
+        }
+    }
+    return els
+}


### PR DESCRIPTION
Modifies the Scannable (now called Element) interface to support argument population and tracking. The Element.Scan() method now has the following signature:

```go
func (b []byte, args []interface{}) (int, int)
```

It accepts a buffer for the SQL string that will be populated and a slice of interface{} variables that will eventually be passed to `database/sql.Query()`

Included in this patch is support for new `Expression` elements which accept a left and a right side argument and generate SQL for the template "left OP right" where `OP` is the operator.

Issue #11 