### PR TITLE
Add support for IN expression

### DIFF
--- a/expression_test.go
+++ b/expression_test.go
@@ -358,3 +358,81 @@ func TestNotEqualFuncTwoElements(t *testing.T) {
     assert.Equal(expArgCount, numArgs)
     assert.Equal(0, len(args))
 }
+
+func TestInSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    e := In(c, "foo")
+
+    exp := "name IN (?)"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 1)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(expArgCount, len(args))
+}
+
+func TestInMulti(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    e := In(c, "foo", "bar", 1)
+
+    exp := "name IN (?, ?, ?)"
+    expLen := len(exp)
+    expArgCount := 3
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, 3)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(expArgCount, len(args))
+}

--- a/select.go
+++ b/select.go
@@ -74,9 +74,9 @@ func Select(items ...Element) *Selectable {
 
     subjSet := make(map[Element]bool, 0)
 
-    // For each scannable item we're received in the call, check what concrete
+    // For each scannable item we've received in the call, check what concrete
     // type they are and, depending on which type they are, either add them to
-    // the returned Selectable's projected ColumnList or query the underlying
+    // the returned Selectable's projected List or query the underlying
     // table metadata to generate a list of all columns in that table.
     for _, item := range items {
         switch item.(type) {

--- a/symbol.go
+++ b/symbol.go
@@ -11,6 +11,12 @@ var (
     SYM_SELECT_LEN = 7
     SYM_FROM = []byte(" FROM ")
     SYM_FROM_LEN = 6
+    SYM_LPAREN = []byte("(")
+    SYM_LPAREN_LEN = 1
+    SYM_RPAREN = []byte(")")
+    SYM_RPAREN_LEN = 1
+    SYM_IN = []byte(" IN (")
+    SYM_IN_LEN = 5
 
     SYM_OP = map[Op][]byte{
         OP_EQUAL: []byte(" = "),

--- a/util.go
+++ b/util.go
@@ -15,3 +15,15 @@ func toElements(vars ...interface{}) []Element {
     }
     return els
 }
+
+// Given a variable number of interface{} variables, returns a List containing
+// Value structs for the variables
+// If any of the interface{} variables are *not* of type Element already, we
+// construct a Value{} for the variable.
+func toValueList(vars ...interface{}) *List {
+    els := make([]Element, len(vars))
+    for x, v := range vars {
+        els[x] = &Value{value: v}
+    }
+    return &List{elements: els}
+}

--- a/value.go
+++ b/value.go
@@ -13,7 +13,9 @@ func (val *Value) ArgCount() int {
 }
 
 func (val  *Value) Size() int {
-    return 1  // The valeral is always injected as a question mark
+    // The value is always injected as a question mark in the produced SQL
+    // string
+    return 1
 }
 
 func (val *Value) Scan(b []byte, args []interface{}) (int, int) {


### PR DESCRIPTION
Adds support for the IN (...) SQL expression. A new sqlb.In() function
returns a specialized InExpression struct pointer that outputs
appropriate question mark interpolated variables to the produced SQL
string.

Issue #11