### PR TITLE
Support for WHERE, AND, OR, and BETWEEN

### DIFF
--- a/column.go
+++ b/column.go
@@ -12,7 +12,7 @@ func (c *Column) ArgCount() int {
 func (c *Column) Size() int {
     size := c.def.Size()
     if c.alias != "" {
-        size += SYM_AS_LEN + len(c.alias)
+        size += len(Symbols[SYM_AS]) + len(c.alias)
     }
     return size
 }
@@ -20,7 +20,7 @@ func (c *Column) Size() int {
 func (c *Column) Scan(b []byte, args []interface{}) (int, int) {
     bw, _ := c.def.Scan(b, args)
     if c.alias != "" {
-        bw += copy(b[bw:], SYM_AS)
+        bw += copy(b[bw:], Symbols[SYM_AS])
         bw += copy(b[bw:], c.alias)
     }
     return bw, 0

--- a/expression.go
+++ b/expression.go
@@ -6,6 +6,7 @@ const (
     OP_EQUAL = iota
     OP_NEQUAL
     OP_AND
+    OP_OR
 )
 
 type Expression struct {
@@ -51,6 +52,10 @@ func NotEqual(left interface{}, right interface{}) *Expression {
 
 func And(a *Expression, b *Expression) *Expression {
     return &Expression{op: OP_AND, left: a, right: b}
+}
+
+func Or(a *Expression, b *Expression) *Expression {
+    return &Expression{op: OP_OR, left: a, right: b}
 }
 
 type InExpression struct {

--- a/expression.go
+++ b/expression.go
@@ -5,7 +5,7 @@ type Op int
 const (
     OP_EQUAL = iota
     OP_NEQUAL
-    OP_IN
+    OP_AND
 )
 
 type Expression struct {
@@ -25,7 +25,7 @@ func (e *Expression) Size() int {
 func (e *Expression) Scan(b []byte, args []interface{}) (int, int) {
     bw, ac := e.left.Scan(b, args)
     bw += copy(b[bw:], SYM_OP[e.op])
-    rbw, rac := e.right.Scan(b[bw:], args)
+    rbw, rac := e.right.Scan(b[bw:], args[ac:])
     bw += rbw
     ac += rac
     return bw, ac
@@ -47,6 +47,10 @@ func NotEqual(left interface{}, right interface{}) *Expression {
         left: els[0],
         right: els[1],
     }
+}
+
+func And(a *Expression, b *Expression) *Expression {
+    return &Expression{op: OP_AND, left: a, right: b}
 }
 
 type InExpression struct {

--- a/expression_test.go
+++ b/expression_test.go
@@ -26,7 +26,7 @@ func TestExpressionEqual(t *testing.T) {
     val := &Value{value: "foo"}
 
     e := &Expression{
-        op: OP_EQUAL,
+        scanInfo: exprScanTable[OP_EQUAL],
         left: c,
         right: val,
     }
@@ -55,7 +55,7 @@ func TestExpressionEqual(t *testing.T) {
     // the left and right expression reversed
 
     erev := &Expression{
-        op: OP_EQUAL,
+        scanInfo: exprScanTable[OP_EQUAL],
         left: val,
         right: c,
     }
@@ -217,7 +217,7 @@ func TestExpressionNotEqual(t *testing.T) {
     val := &Value{value: "foo"}
 
     e := &Expression{
-        op: OP_NEQUAL,
+        scanInfo: exprScanTable[OP_NEQUAL],
         left: c,
         right: val,
     }
@@ -455,13 +455,13 @@ func TestAnd(t *testing.T) {
     }
 
     ea := &Expression{
-        op: OP_NEQUAL,
+        scanInfo: exprScanTable[OP_NEQUAL],
         left: c,
         right: &Value{value: "foo"},
     }
 
     eb := &Expression{
-        op: OP_NEQUAL,
+        scanInfo: exprScanTable[OP_NEQUAL],
         left: c,
         right: &Value{value: "bar"},
     }
@@ -507,13 +507,13 @@ func TestOr(t *testing.T) {
     }
 
     ea := &Expression{
-        op: OP_EQUAL,
+        scanInfo: exprScanTable[OP_EQUAL],
         left: c,
         right: &Value{value: "foo"},
     }
 
     eb := &Expression{
-        op: OP_EQUAL,
+        scanInfo: exprScanTable[OP_EQUAL],
         left: c,
         right: &Value{value: "bar"},
     }

--- a/expression_test.go
+++ b/expression_test.go
@@ -436,3 +436,55 @@ func TestInMulti(t *testing.T) {
     assert.Equal(expArgCount, numArgs)
     assert.Equal(expArgCount, len(args))
 }
+
+func TestAnd(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    ea := &Expression{
+        op: OP_NEQUAL,
+        left: c,
+        right: &Value{value: "foo"},
+    }
+
+    eb := &Expression{
+        op: OP_NEQUAL,
+        left: c,
+        right: &Value{value: "bar"},
+    }
+    e := And(ea, eb)
+
+    exp := "name != ? AND name != ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(expArgCount, len(args))
+    assert.Equal("foo", args[0])
+    assert.Equal("bar", args[1])
+}

--- a/expression_test.go
+++ b/expression_test.go
@@ -26,9 +26,8 @@ func TestExpressionEqual(t *testing.T) {
     val := &Value{value: "foo"}
 
     e := &Expression{
-        scanInfo: exprScanTable[OP_EQUAL],
-        left: c,
-        right: val,
+        scanInfo: exprScanTable[EXP_EQUAL],
+        elements: []Element{c, val},
     }
 
     exp := "name = ?"
@@ -55,9 +54,8 @@ func TestExpressionEqual(t *testing.T) {
     // the left and right expression reversed
 
     erev := &Expression{
-        scanInfo: exprScanTable[OP_EQUAL],
-        left: val,
-        right: c,
+        scanInfo: exprScanTable[EXP_EQUAL],
+        elements: []Element{val, c},
     }
 
     exp = "? = name"
@@ -217,9 +215,8 @@ func TestExpressionNotEqual(t *testing.T) {
     val := &Value{value: "foo"}
 
     e := &Expression{
-        scanInfo: exprScanTable[OP_NEQUAL],
-        left: c,
-        right: val,
+        scanInfo: exprScanTable[EXP_NEQUAL],
+        elements: []Element{c, val},
     }
 
     exp := "name != ?"
@@ -455,15 +452,13 @@ func TestAnd(t *testing.T) {
     }
 
     ea := &Expression{
-        scanInfo: exprScanTable[OP_NEQUAL],
-        left: c,
-        right: &Value{value: "foo"},
+        scanInfo: exprScanTable[EXP_NEQUAL],
+        elements: []Element{c, &Value{value: "foo"}},
     }
 
     eb := &Expression{
-        scanInfo: exprScanTable[OP_NEQUAL],
-        left: c,
-        right: &Value{value: "bar"},
+        scanInfo: exprScanTable[EXP_NEQUAL],
+        elements: []Element{c, &Value{value: "bar"}},
     }
     e := And(ea, eb)
 
@@ -507,15 +502,13 @@ func TestOr(t *testing.T) {
     }
 
     ea := &Expression{
-        scanInfo: exprScanTable[OP_EQUAL],
-        left: c,
-        right: &Value{value: "foo"},
+        scanInfo: exprScanTable[EXP_EQUAL],
+        elements: []Element{c, &Value{value: "foo"}},
     }
 
     eb := &Expression{
-        scanInfo: exprScanTable[OP_EQUAL],
-        left: c,
-        right: &Value{value: "bar"},
+        scanInfo: exprScanTable[EXP_EQUAL],
+        elements: []Element{c, &Value{value: "bar"}},
     }
     e := Or(ea, eb)
 

--- a/expression_test.go
+++ b/expression_test.go
@@ -488,3 +488,55 @@ func TestAnd(t *testing.T) {
     assert.Equal("foo", args[0])
     assert.Equal("bar", args[1])
 }
+
+func TestOr(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    ea := &Expression{
+        op: OP_EQUAL,
+        left: c,
+        right: &Value{value: "foo"},
+    }
+
+    eb := &Expression{
+        op: OP_EQUAL,
+        left: c,
+        right: &Value{value: "bar"},
+    }
+    e := Or(ea, eb)
+
+    exp := "name = ? OR name = ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    s := e.Size()
+    assert.Equal(expLen, s)
+
+    argc := e.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := e.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(expArgCount, len(args))
+    assert.Equal("foo", args[0])
+    assert.Equal("bar", args[1])
+}

--- a/list.go
+++ b/list.go
@@ -20,7 +20,7 @@ func (l  *List) Size() int {
     for _, el := range l.elements {
         size += el.Size()
     }
-    return size + (SYM_COMMA_WS_LEN * (nels - 1))  // the commas...
+    return size + (len(Symbols[SYM_COMMA_WS]) * (nels - 1))  // the commas...
 }
 
 func (l *List) Scan(b []byte, args []interface{}) (int, int) {
@@ -30,7 +30,7 @@ func (l *List) Scan(b []byte, args []interface{}) (int, int) {
         ebw, eac := el.Scan(b[bw:], args[ac:])
         bw += ebw
         if x != (nels - 1) {
-            bw += copy(b[bw:], SYM_COMMA_WS)
+            bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
         }
         ac += eac
     }

--- a/select.go
+++ b/select.go
@@ -28,18 +28,18 @@ func (s *Selectable) As(alias string) *Selectable {
 }
 
 func (s *Selectable) Size() int {
-    size := SYM_SELECT_LEN + SYM_FROM_LEN
+    size := len(Symbols[SYM_SELECT]) + len(Symbols[SYM_FROM])
     size += s.projected.Size()
     for _, subj := range s.subjects {
         size += subj.Size()
     }
     if s.alias != "" {
-        size += SYM_AS_LEN + len(s.alias)
+        size += len(Symbols[SYM_AS]) + len(s.alias)
     }
     nfilters := len(s.filters)
     if nfilters > 0 {
-        size += SYM_WHERE_LEN
-        size += SYM_AND_LEN * (nfilters - 1)
+        size += len(Symbols[SYM_WHERE])
+        size += len(Symbols[SYM_AND]) * (nfilters - 1)
         for _, filter := range s.filters {
             size += filter.Size()
         }
@@ -49,25 +49,25 @@ func (s *Selectable) Size() int {
 
 func (s *Selectable) Scan(b []byte, args []interface{}) (int, int) {
     var bw, ac int
-    bw += copy(b[bw:], SYM_SELECT)
+    bw += copy(b[bw:], Symbols[SYM_SELECT])
     pbw, pac := s.projected.Scan(b[bw:], args)
     bw += pbw
     ac += pac
-    bw += copy(b[bw:], SYM_FROM)
+    bw += copy(b[bw:], Symbols[SYM_FROM])
     for _, subj := range s.subjects {
         sbw, sac := subj.Scan(b[bw:], args)
         bw += sbw
         ac += sac
     }
     if s.alias != "" {
-        bw += copy(b[bw:], SYM_AS)
+        bw += copy(b[bw:], Symbols[SYM_AS])
         bw += copy(b[bw:], s.alias)
     }
     if len(s.filters) > 0 {
-        bw += copy(b[bw:], SYM_WHERE)
+        bw += copy(b[bw:], Symbols[SYM_WHERE])
         for x, filter := range s.filters {
             if x > 0 {
-                bw += copy(b[bw:], SYM_AND)
+                bw += copy(b[bw:], Symbols[SYM_AND])
             }
             fbw, fac := filter.Scan(b[bw:], args[ac:])
             bw += fbw

--- a/select_test.go
+++ b/select_test.go
@@ -172,3 +172,105 @@ func TestWhereSingleEqual(t *testing.T) {
     assert.Equal(expArgCount, sel.ArgCount())
     assert.Equal(exp, sel.String())
 }
+
+func TestWhereSingleAnd(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).Where(And(NotEqual(cd, "foo"), NotEqual(cd, "bar")))
+
+    exp := "SELECT name FROM users WHERE name != ? AND name != ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestWhereSingleIn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).Where(In(cd, "foo", "bar"))
+
+    exp := "SELECT name FROM users WHERE name IN (?, ?)"
+    expLen := len(exp)
+    expArgCount := 2
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestWhereMultiNotEqual(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).Where(NotEqual(cd, "foo"))
+    sel = sel.Where(NotEqual(cd, "bar"))
+
+    exp := "SELECT name FROM users WHERE name != ? AND name != ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestWhereMultiInAndEqual(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "is_author",
+        table: td,
+    }
+
+    sel := Select(cd1).Where(And(In(cd1, "foo", "bar"), Equal(cd2, 1)))
+
+    exp := "SELECT name FROM users WHERE name IN (?, ?) AND is_author = ?"
+    expLen := len(exp)
+    expArgCount := 3
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/select_test.go
+++ b/select_test.go
@@ -148,3 +148,27 @@ func TestSelectFromTableDef(t *testing.T) {
     assert.Equal(expLen, sel.Size())
     assert.Equal(exp, sel.String())
 }
+
+func TestWhereSingleEqual(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).Where(Equal(cd, "foo"))
+
+    exp := "SELECT name FROM users WHERE name = ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/symbol.go
+++ b/symbol.go
@@ -22,5 +22,6 @@ var (
         OP_EQUAL: []byte(" = "),
         OP_NEQUAL: []byte(" != "),
         OP_AND: []byte(" AND "),
+        OP_OR: []byte(" OR "),
     }
 )

--- a/symbol.go
+++ b/symbol.go
@@ -21,5 +21,6 @@ var (
     SYM_OP = map[Op][]byte{
         OP_EQUAL: []byte(" = "),
         OP_NEQUAL: []byte(" != "),
+        OP_AND: []byte(" AND "),
     }
 )

--- a/symbol.go
+++ b/symbol.go
@@ -1,6 +1,8 @@
 package sqlb
 
 var (
+    SYM_EMPTY = []byte("")
+    SYM_EMPTY_LEN = 0
     SYM_QM = []byte("?")
     SYM_QM_LEN = 1
     SYM_AS = []byte(" AS ")
@@ -21,11 +23,10 @@ var (
     SYM_WHERE_LEN = 7
     SYM_AND = []byte(" AND ")
     SYM_AND_LEN = 5
-
-    SYM_OP = map[Op][]byte{
-        OP_EQUAL: []byte(" = "),
-        OP_NEQUAL: []byte(" != "),
-        OP_AND: []byte(" AND "),
-        OP_OR: []byte(" OR "),
-    }
+    SYM_OR = []byte(" OR ")
+    SYM_OR_LEN = 4
+    SYM_EQUAL = []byte(" = ")
+    SYM_EQUAL_LEN = 3
+    SYM_NEQUAL = []byte(" != ")
+    SYM_NEQUAL_LEN = 4
 )

--- a/symbol.go
+++ b/symbol.go
@@ -1,32 +1,40 @@
 package sqlb
 
+type Symbol int
+
+const (
+    SYM_ELEMENT = iota // Marker for an element that self-scans into the SQL buffer
+    SYM_QUEST_MARK
+    SYM_AS
+    SYM_COMMA_WS
+    SYM_SELECT
+    SYM_FROM
+    SYM_LPAREN
+    SYM_RPAREN
+    SYM_IN
+    SYM_WHERE
+    SYM_AND
+    SYM_OR
+    SYM_EQUAL
+    SYM_NEQUAL
+    SYM_BETWEEN
+)
+
 var (
-    SYM_EMPTY = []byte("")
-    SYM_EMPTY_LEN = 0
-    SYM_QM = []byte("?")
-    SYM_QM_LEN = 1
-    SYM_AS = []byte(" AS ")
-    SYM_AS_LEN = 4
-    SYM_COMMA_WS = []byte(", ")
-    SYM_COMMA_WS_LEN = 2
-    SYM_SELECT = []byte("SELECT ")
-    SYM_SELECT_LEN = 7
-    SYM_FROM = []byte(" FROM ")
-    SYM_FROM_LEN = 6
-    SYM_LPAREN = []byte("(")
-    SYM_LPAREN_LEN = 1
-    SYM_RPAREN = []byte(")")
-    SYM_RPAREN_LEN = 1
-    SYM_IN = []byte(" IN (")
-    SYM_IN_LEN = 5
-    SYM_WHERE = []byte(" WHERE ")
-    SYM_WHERE_LEN = 7
-    SYM_AND = []byte(" AND ")
-    SYM_AND_LEN = 5
-    SYM_OR = []byte(" OR ")
-    SYM_OR_LEN = 4
-    SYM_EQUAL = []byte(" = ")
-    SYM_EQUAL_LEN = 3
-    SYM_NEQUAL = []byte(" != ")
-    SYM_NEQUAL_LEN = 4
+    Symbols = map[Symbol][]byte{
+        SYM_QUEST_MARK: []byte("?"),
+        SYM_AS: []byte(" AS "),
+        SYM_COMMA_WS: []byte(", "),
+        SYM_SELECT: []byte("SELECT "),
+        SYM_FROM: []byte(" FROM "),
+        SYM_LPAREN: []byte("("),
+        SYM_RPAREN: []byte(")"),
+        SYM_IN: []byte(" IN ("),
+        SYM_WHERE: []byte(" WHERE "),
+        SYM_AND: []byte(" AND "),
+        SYM_OR: []byte(" OR "),
+        SYM_EQUAL: []byte(" = "),
+        SYM_NEQUAL: []byte(" != "),
+        SYM_BETWEEN: []byte(" BETWEEN "),
+    }
 )

--- a/symbol.go
+++ b/symbol.go
@@ -17,6 +17,10 @@ var (
     SYM_RPAREN_LEN = 1
     SYM_IN = []byte(" IN (")
     SYM_IN_LEN = 5
+    SYM_WHERE = []byte(" WHERE ")
+    SYM_WHERE_LEN = 7
+    SYM_AND = []byte(" AND ")
+    SYM_AND_LEN = 5
 
     SYM_OP = map[Op][]byte{
         OP_EQUAL: []byte(" = "),

--- a/table.go
+++ b/table.go
@@ -22,7 +22,7 @@ func (t *Table) ArgCount() int {
 func (t *Table) Size() int {
     size := t.def.Size()
     if t.alias != "" {
-        size += SYM_AS_LEN + len(t.alias)
+        size += len(Symbols[SYM_AS]) + len(t.alias)
     }
     return size
 }
@@ -30,7 +30,7 @@ func (t *Table) Size() int {
 func (t *Table) Scan(b []byte, args []interface{}) (int, int) {
     bw, _ := t.def.Scan(b, args)
     if t.alias != "" {
-        bw += copy(b[bw:], SYM_AS)
+        bw += copy(b[bw:], Symbols[SYM_AS])
         bw += copy(b[bw:], t.alias)
     }
     return bw, 0

--- a/value.go
+++ b/value.go
@@ -20,6 +20,6 @@ func (val  *Value) Size() int {
 
 func (val *Value) Scan(b []byte, args []interface{}) (int, int) {
     args[0] = val.value
-    copy(b, SYM_QM)
+    copy(b, Symbols[SYM_QUEST_MARK])
     return 1, 1
 }


### PR DESCRIPTION
Major reworking of the Expression struct to be more flexible and support more varied string templates in the Scan() method.

Users can now use the `sqlb.Selectable.Where()` method to add filters to a SELECT expression, like so:

```go
users := meta.Table("users")

isAuthorCol := users.Column("is_author")
nameCol := users.Column("name")

cond := sqlb.And(sqlb.Equal(isAuthor, 1), sqlb.In(nameCol, "foo", "bar"))
sel := sqlb.Select(users).Where(cond)
```

Closes Issue #11 