### PR TITLE
Support the LIMIT X [OFFSET Y] SQL clause

### DIFF
--- a/limit.go
+++ b/limit.go
@@ -1,0 +1,36 @@
+package sqlb
+
+type LimitClause struct {
+    limit int
+    offset *int
+}
+
+func (lc *LimitClause) ArgCount() int {
+    if lc.offset == nil {
+        return 1
+    }
+    return 2
+}
+
+func (lc *LimitClause) Size() int {
+    size := len(Symbols[SYM_LIMIT]) + len(Symbols[SYM_QUEST_MARK])
+    if lc.offset != nil {
+        size += len(Symbols[SYM_OFFSET]) + len(Symbols[SYM_QUEST_MARK])
+    }
+    return size
+}
+
+func (lc *LimitClause) Scan(b []byte, args []interface{}) (int, int) {
+    var bw, ac int
+    bw += copy(b[bw:], Symbols[SYM_LIMIT])
+    bw += copy(b[bw:], Symbols[SYM_QUEST_MARK])
+    args[ac] = lc.limit
+    ac++
+    if lc.offset != nil {
+        bw += copy(b[bw:], Symbols[SYM_OFFSET])
+        bw += copy(b[bw:], Symbols[SYM_QUEST_MARK])
+        args[ac] = *lc.offset
+        ac++
+    }
+    return bw, ac
+}

--- a/limit_test.go
+++ b/limit_test.go
@@ -1,0 +1,64 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestLimitClause(t *testing.T) {
+    assert := assert.New(t)
+
+    lc := &LimitClause{
+        limit: 20,
+    }
+
+    exp := " LIMIT ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := lc.Size()
+    assert.Equal(expLen, s)
+
+    argc := lc.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := lc.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(20, args[0])
+}
+
+func TestLimitClauseWithOffset(t *testing.T) {
+    assert := assert.New(t)
+
+    lc := &LimitClause{
+        limit: 20,
+    }
+    offset := 10
+    lc.offset = &offset
+
+    exp := " LIMIT ? OFFSET ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    s := lc.Size()
+    assert.Equal(expLen, s)
+
+    argc := lc.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := lc.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal(20, args[0])
+    assert.Equal(10, args[1])
+}

--- a/select_test.go
+++ b/select_test.go
@@ -274,3 +274,59 @@ func TestWhereMultiInAndEqual(t *testing.T) {
     assert.Equal(expArgCount, sel.ArgCount())
     assert.Equal(exp, sel.String())
 }
+
+func TestSelectLimit(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    sel := Select(c).Limit(10)
+
+    exp := "SELECT name FROM users LIMIT ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectLimitWithOffset(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    sel := Select(c).LimitWithOffset(10, 5)
+
+    exp := "SELECT name FROM users LIMIT ? OFFSET ?"
+    expLen := len(exp)
+    expArgCount := 2
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/symbol.go
+++ b/symbol.go
@@ -18,6 +18,8 @@ const (
     SYM_EQUAL
     SYM_NEQUAL
     SYM_BETWEEN
+    SYM_LIMIT
+    SYM_OFFSET
 )
 
 var (
@@ -36,5 +38,7 @@ var (
         SYM_EQUAL: []byte(" = "),
         SYM_NEQUAL: []byte(" != "),
         SYM_BETWEEN: []byte(" BETWEEN "),
+        SYM_LIMIT: []byte(" LIMIT "),
+        SYM_OFFSET: []byte(" OFFSET "),
     }
 )


### PR DESCRIPTION
Adds support for specifying the LIMIT X [OFFSET Y] clause. A new
LimitClause struct Element implementation is created and the Selectable
struct gains a Limit() and LimitWithOffset() method to append the LIMIT
clause to itself.

Closes Issue #17