### PR TITLE
Initial ORDER BY support

### DIFF
--- a/column.go
+++ b/column.go
@@ -35,6 +35,14 @@ func (c *Column) As(alias string) *Column {
     return c
 }
 
+func (c *Column) Desc() *SortColumn {
+    return &SortColumn{el: c, desc: true}
+}
+
+func (c *Column) Asc() *SortColumn {
+    return &SortColumn{el: c}
+}
+
 func isColumn(el Element) bool {
     switch el.(type) {
     case *Column:

--- a/column_test.go
+++ b/column_test.go
@@ -35,6 +35,90 @@ func TestColumn(t *testing.T) {
     assert.Equal(exp, string(b))
 }
 
+func TestColumnDefSorts(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sc := cd.Asc()
+
+    exp := "name"
+    expLen := len(exp)
+    s := sc.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written, _ := sc.Scan(b, nil)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+
+    sc = cd.Desc()
+
+    exp = "name DESC"
+    expLen = len(exp)
+    s = sc.Size()
+    assert.Equal(expLen, s)
+
+    b = make([]byte, s)
+    written, _ = sc.Scan(b, nil)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}
+
+func TestColumnSorts(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    c := &Column{
+        def: cd,
+    }
+
+    sc := c.Asc()
+
+    exp := "name"
+    expLen := len(exp)
+    s := sc.Size()
+    assert.Equal(expLen, s)
+
+    b := make([]byte, s)
+    written, _ := sc.Scan(b, nil)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+
+    sc = c.Desc()
+
+    exp = "name DESC"
+    expLen = len(exp)
+    s = sc.Size()
+    assert.Equal(expLen, s)
+
+    b = make([]byte, s)
+    written, _ = sc.Scan(b, nil)
+
+    assert.Equal(written, s)
+    assert.Equal(exp, string(b))
+}
+
 func TestColumnAlias(t *testing.T) {
     assert := assert.New(t)
 

--- a/meta.go
+++ b/meta.go
@@ -50,6 +50,14 @@ func (c *ColumnDef) As(alias string) *Column {
     return &Column{def: c, alias: alias}
 }
 
+func (c *ColumnDef) Desc() *SortColumn {
+    return &SortColumn{el: c, desc: true}
+}
+
+func (c *ColumnDef) Asc() *SortColumn {
+    return &SortColumn{el: c}
+}
+
 type TableDef struct {
     name string
     schema string

--- a/order_by.go
+++ b/order_by.go
@@ -1,0 +1,48 @@
+package sqlb
+
+
+type sortColumn struct {
+    el Element
+    desc bool
+}
+
+type OrderByClause struct {
+    cols []*sortColumn
+}
+
+func (ob *OrderByClause) ArgCount() int {
+    argc := 0
+    for _, col := range ob.cols {
+        argc += col.el.ArgCount()
+    }
+    return argc
+}
+
+func (ob *OrderByClause) Size() int {
+    size := len(Symbols[SYM_ORDER_BY])
+    for _, col := range ob.cols {
+        size += col.el.Size()
+        if col.desc {
+            size += len(Symbols[SYM_DESC])
+        }
+    }
+    size += ((len(ob.cols) - 1) * len(Symbols[SYM_COMMA_WS]))
+    return size
+}
+
+func (ob *OrderByClause) Scan(b []byte, args []interface{}) (int, int) {
+    var bw, ac int
+    bw += copy(b[bw:], Symbols[SYM_ORDER_BY])
+    for x, col := range ob.cols {
+        if x > 0 {
+            bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
+        }
+        ebw, eac := col.el.Scan(b[bw:], args[ac:])
+        bw += ebw
+        ac += eac
+        if col.desc {
+            bw += copy(b[bw:], Symbols[SYM_DESC])
+        }
+    }
+    return bw, ac
+}

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -20,8 +20,10 @@ func TestOrderByClauseSingleAsc(t *testing.T) {
     }
 
     ob := &OrderByClause{
-        cols: []*sortColumn{
-            &sortColumn{el: cd},
+        cols: &List{
+            elements: []Element{
+                &SortColumn{el: cd},
+            },
         },
     }
 
@@ -58,8 +60,10 @@ func TestOrderByClauseSingleDesc(t *testing.T) {
     }
 
     ob := &OrderByClause{
-        cols: []*sortColumn{
-            &sortColumn{el: cd, desc: true},
+        cols: &List{
+            elements: []Element{
+                &SortColumn{el: cd, desc: true},
+            },
         },
     }
 
@@ -101,9 +105,11 @@ func TestOrderByClauseMultiAsc(t *testing.T) {
     }
 
     ob := &OrderByClause{
-        cols: []*sortColumn{
-            &sortColumn{el: cd1},
-            &sortColumn{el: cd2},
+        cols: &List{
+            elements: []Element{
+                &SortColumn{el: cd1},
+                &SortColumn{el: cd2},
+            },
         },
     }
 
@@ -145,9 +151,11 @@ func TestOrderByClauseMultiAscDesc(t *testing.T) {
     }
 
     ob := &OrderByClause{
-        cols: []*sortColumn{
-            &sortColumn{el: cd1},
-            &sortColumn{el: cd2, desc: true},
+        cols: &List{
+            elements: []Element{
+                &SortColumn{el: cd1},
+                &SortColumn{el: cd2, desc: true},
+            },
         },
     }
 

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -1,0 +1,171 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestOrderByClauseSingleAsc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    ob := &OrderByClause{
+        cols: []*sortColumn{
+            &sortColumn{el: cd},
+        },
+    }
+
+    exp := " ORDER BY name"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestOrderByClauseSingleDesc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    ob := &OrderByClause{
+        cols: []*sortColumn{
+            &sortColumn{el: cd, desc: true},
+        },
+    }
+
+    exp := " ORDER BY name DESC"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestOrderByClauseMultiAsc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    ob := &OrderByClause{
+        cols: []*sortColumn{
+            &sortColumn{el: cd1},
+            &sortColumn{el: cd2},
+        },
+    }
+
+    exp := " ORDER BY name, email"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestOrderByClauseMultiAscDesc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    ob := &OrderByClause{
+        cols: []*sortColumn{
+            &sortColumn{el: cd1},
+            &sortColumn{el: cd2, desc: true},
+        },
+    }
+
+    exp := " ORDER BY name, email DESC"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}

--- a/select_test.go
+++ b/select_test.go
@@ -330,3 +330,56 @@ func TestSelectLimitWithOffset(t *testing.T) {
     assert.Equal(expArgCount, sel.ArgCount())
     assert.Equal(exp, sel.String())
 }
+
+func TestSelectOrderByAsc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).OrderBy(cd.Asc())
+
+    exp := "SELECT name FROM users ORDER BY name"
+    expLen := len(exp)
+    expArgCount := 0
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectOrderByMultiAscDesc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    sel := Select(cd1).OrderBy(cd1.Asc(), cd2.Desc())
+
+    exp := "SELECT name FROM users ORDER BY name, email DESC"
+    expLen := len(exp)
+    expArgCount := 0
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/symbol.go
+++ b/symbol.go
@@ -20,6 +20,8 @@ const (
     SYM_BETWEEN
     SYM_LIMIT
     SYM_OFFSET
+    SYM_ORDER_BY
+    SYM_DESC
 )
 
 var (
@@ -40,5 +42,7 @@ var (
         SYM_BETWEEN: []byte(" BETWEEN "),
         SYM_LIMIT: []byte(" LIMIT "),
         SYM_OFFSET: []byte(" OFFSET "),
+        SYM_ORDER_BY: []byte(" ORDER BY "),
+        SYM_DESC: []byte(" DESC"),
     }
 )


### PR DESCRIPTION
Adds support for the `ORDER BY` SQL clause. The `sqlb.Selectable` struct now has an `OrderBy()` method that accepts one or more SortColumn struct pointers. SortColumn structs implement the Element interface and can be generated from new `Column[Def].Desc()` and `Column[Def].Asc()` methods, like so:

```go
users := meta.Table("users")

nameCol := users.Column("name")
emailCol := users.Column("email")

sel := sqlb.Select(users).OrderBy(nameCol.Asc(), emailCol.Desc())

// sel.String() would generated "SELECT name, email FROM users ORDER BY name, email DESC"
```

Issue #19  