### PR TITLE
 Support SELECT ... GROUP BY SQL clause

### DIFF
--- a/column.go
+++ b/column.go
@@ -1,8 +1,16 @@
 package sqlb
 
+type Columnar interface {
+    Column() *Column
+}
+
 type Column struct {
     alias string
     def *ColumnDef
+}
+
+func (c *Column) Column() *Column {
+    return c
 }
 
 func (c *Column) ArgCount() int {

--- a/group_by.go
+++ b/group_by.go
@@ -1,0 +1,25 @@
+package sqlb
+
+type GroupByClause struct {
+    cols *List
+}
+
+func (ob *GroupByClause) ArgCount() int {
+    argc := 0
+    return argc
+}
+
+func (ob *GroupByClause) Size() int {
+    size := len(Symbols[SYM_GROUP_BY])
+    size += ob.cols.Size()
+    return size
+}
+
+func (ob *GroupByClause) Scan(b []byte, args []interface{}) (int, int) {
+    var bw, ac int
+    bw += copy(b[bw:], Symbols[SYM_GROUP_BY])
+    ebw, eac := ob.cols.Scan(b[bw:], args[ac:])
+    bw += ebw
+    ac += eac
+    return bw, ac
+}

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -1,0 +1,88 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestGroupByClauseSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    ob := &GroupByClause{
+        cols: &List{
+            elements: []Element{cd},
+        },
+    }
+
+    exp := " GROUP BY name"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestGroupByClauseMulti(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    ob := &GroupByClause{
+        cols: &List{
+            elements: []Element{cd1, cd2},
+        },
+    }
+
+    exp := " GROUP BY name, email"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := ob.Size()
+    assert.Equal(expLen, s)
+
+    argc := ob.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := ob.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}

--- a/meta.go
+++ b/meta.go
@@ -33,6 +33,10 @@ type ColumnDef struct {
     table *TableDef
 }
 
+func (c *ColumnDef) Column() *Column {
+    return &Column{def: c}
+}
+
 func (c *ColumnDef) ArgCount() int {
     return 0
 }

--- a/select_test.go
+++ b/select_test.go
@@ -412,3 +412,80 @@ func TestSelectStringArgs(t *testing.T) {
     assert.Equal(expStr, actStr)
     assert.Equal(expArgs, actArgs)
 }
+
+func TestSelectGroupByAsc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).GroupBy(cd)
+
+    exp := "SELECT name FROM users GROUP BY name"
+    expLen := len(exp)
+    expArgCount := 0
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectGroupByMultiAscDesc(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd1 := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    cd2 := &ColumnDef{
+        name: "email",
+        table: td,
+    }
+
+    sel := Select(cd1).GroupBy(cd1, cd2)
+
+    exp := "SELECT name FROM users GROUP BY name, email"
+    expLen := len(exp)
+    expArgCount := 0
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}
+
+func TestSelectGroupOrderLimit(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "name",
+        table: td,
+    }
+
+    sel := Select(cd).GroupBy(cd).OrderBy(cd.Desc()).Limit(10)
+
+    exp := "SELECT name FROM users GROUP BY name ORDER BY name DESC LIMIT ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/symbol.go
+++ b/symbol.go
@@ -22,6 +22,7 @@ const (
     SYM_OFFSET
     SYM_ORDER_BY
     SYM_DESC
+    SYM_GROUP_BY
 )
 
 var (
@@ -44,5 +45,6 @@ var (
         SYM_OFFSET: []byte(" OFFSET "),
         SYM_ORDER_BY: []byte(" ORDER BY "),
         SYM_DESC: []byte(" DESC"),
+        SYM_GROUP_BY: []byte(" GROUP BY "),
     }
 )


### PR DESCRIPTION
Adds a `GroupBy()` method to the `Selectable` struct, allowing the user to specify one or more columns on which to group by. Columns and ColumnDefs are allowed in the `Selectable.GroupBy()` method, as shown here:

```go
users := meta.Table("users")

emailColDef := users.ColumnDef("email")
nameCol := users.Column("name")

sel := sqlb.Select(users).GroupBy(nameCol, emailColDef)

// sel.String == "SELECT name, email FROM users GROUP BY name, email"
```

Closes Issue #21