### PR TITLE
Support basic SQL functions: MAX(), MIN(), SUM(), AVG()

### DIFF
--- a/function.go
+++ b/function.go
@@ -1,0 +1,113 @@
+package sqlb
+
+type funcId int
+
+const (
+    FUNC_MAX funcId = iota
+    FUNC_MIN
+)
+
+var (
+    // A static table containing information used in constructing the
+    // expression's SQL string during Scan() calls
+    funcScanTable = map[funcId]scanInfo{
+        FUNC_MAX: scanInfo{
+            SYM_MAX, SYM_ELEMENT, SYM_RPAREN,
+        },
+        FUNC_MIN: scanInfo{
+            SYM_MIN, SYM_ELEMENT, SYM_RPAREN,
+        },
+    }
+)
+
+type sqlFunc struct {
+    alias string
+    scanInfo scanInfo
+    elements []Element
+}
+
+func (f *sqlFunc) Alias(alias string) {
+    f.alias = alias
+}
+
+func (f *sqlFunc) As(alias string) *sqlFunc {
+    f.Alias(alias)
+    return f
+}
+
+func (e *sqlFunc) ArgCount() int {
+    ac := 0
+    for _, el := range e.elements {
+        ac += el.ArgCount()
+    }
+    return ac
+}
+
+func (f *sqlFunc) Size() int {
+    size := 0
+    elidx := 0
+    for _, sym := range f.scanInfo {
+        if sym == SYM_ELEMENT {
+            el := f.elements[elidx]
+            elidx++
+            size += el.Size()
+        } else {
+            size += len(Symbols[sym])
+        }
+    }
+    if f.alias != "" {
+        size += len(Symbols[SYM_AS]) + len(f.alias)
+    }
+    return size
+}
+
+func (f *sqlFunc) Scan(b []byte, args []interface{}) (int, int) {
+    bw, ac := 0, 0
+    elidx := 0
+    for _, sym := range f.scanInfo {
+        if sym == SYM_ELEMENT {
+            el := f.elements[elidx]
+            elidx++
+            ebw, eac := el.Scan(b[bw:], args[ac:])
+            bw += ebw
+            ac += eac
+        } else {
+            bw += copy(b[bw:], Symbols[sym])
+        }
+    }
+    if f.alias != "" {
+        bw += copy(b[bw:], Symbols[SYM_AS])
+        bw += copy(b[bw:], f.alias)
+    }
+    return bw, ac
+}
+
+func Max(el Element) *sqlFunc {
+    return &sqlFunc{
+        scanInfo: funcScanTable[FUNC_MAX],
+        elements: []Element{el},
+    }
+}
+
+func (c *Column) Max() *sqlFunc {
+    return Max(c)
+}
+
+func (c *ColumnDef) Max() *sqlFunc {
+    return Max(c)
+}
+
+func Min(el Element) *sqlFunc {
+    return &sqlFunc{
+        scanInfo: funcScanTable[FUNC_MIN],
+        elements: []Element{el},
+    }
+}
+
+func (c *Column) Min() *sqlFunc {
+    return Min(c)
+}
+
+func (c *ColumnDef) Min() *sqlFunc {
+    return Min(c)
+}

--- a/function.go
+++ b/function.go
@@ -5,6 +5,8 @@ type funcId int
 const (
     FUNC_MAX funcId = iota
     FUNC_MIN
+    FUNC_SUM
+    FUNC_AVG
 )
 
 var (
@@ -16,6 +18,12 @@ var (
         },
         FUNC_MIN: scanInfo{
             SYM_MIN, SYM_ELEMENT, SYM_RPAREN,
+        },
+        FUNC_SUM: scanInfo{
+            SYM_SUM, SYM_ELEMENT, SYM_RPAREN,
+        },
+        FUNC_AVG: scanInfo{
+            SYM_AVG, SYM_ELEMENT, SYM_RPAREN,
         },
     }
 )
@@ -110,4 +118,34 @@ func (c *Column) Min() *sqlFunc {
 
 func (c *ColumnDef) Min() *sqlFunc {
     return Min(c)
+}
+
+func Sum(el Element) *sqlFunc {
+    return &sqlFunc{
+        scanInfo: funcScanTable[FUNC_SUM],
+        elements: []Element{el},
+    }
+}
+
+func (c *Column) Sum() *sqlFunc {
+    return Sum(c)
+}
+
+func (c *ColumnDef) Sum() *sqlFunc {
+    return Sum(c)
+}
+
+func Avg(el Element) *sqlFunc {
+    return &sqlFunc{
+        scanInfo: funcScanTable[FUNC_AVG],
+        elements: []Element{el},
+    }
+}
+
+func (c *Column) Avg() *sqlFunc {
+    return Avg(c)
+}
+
+func (c *ColumnDef) Avg() *sqlFunc {
+    return Avg(c)
 }

--- a/function_test.go
+++ b/function_test.go
@@ -1,0 +1,217 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestFuncWithAlias(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    m := Max(cd).As("max_created_on")
+
+    exp := "MAX(created_on) AS max_created_on"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := m.Size()
+    assert.Equal(expLen, s)
+
+    argc := m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncMax(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    m := Max(cd)
+
+    exp := "MAX(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := m.Size()
+    assert.Equal(expLen, s)
+
+    argc := m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncMaxColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    m := cd.Max()
+
+    exp := "MAX(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := m.Size()
+    assert.Equal(expLen, s)
+
+    argc := m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+
+    // Test with Column not ColumnDef
+    c := &Column{
+        def: cd,
+    }
+    m = c.Max()
+
+    s = m.Size()
+    assert.Equal(expLen, s)
+
+    argc = m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, expArgCount)
+    b = make([]byte, s)
+    written, numArgs = m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncMin(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    m := Min(cd)
+
+    exp := "MIN(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := m.Size()
+    assert.Equal(expLen, s)
+
+    argc := m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncMinColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    m := cd.Min()
+
+    exp := "MIN(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := m.Size()
+    assert.Equal(expLen, s)
+
+    argc := m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+
+    // Test with Column not ColumnDef
+    c := &Column{
+        def: cd,
+    }
+    m = c.Min()
+
+    s = m.Size()
+    assert.Equal(expLen, s)
+
+    argc = m.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, expArgCount)
+    b = make([]byte, s)
+    written, numArgs = m.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}

--- a/function_test.go
+++ b/function_test.go
@@ -215,3 +215,179 @@ func TestFuncMinColumn(t *testing.T) {
     assert.Equal(exp, string(b))
     assert.Equal(expArgCount, numArgs)
 }
+
+func TestFuncSum(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    f := Sum(cd)
+
+    exp := "SUM(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := f.Size()
+    assert.Equal(expLen, s)
+
+    argc := f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncSumColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    f := cd.Sum()
+
+    exp := "SUM(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := f.Size()
+    assert.Equal(expLen, s)
+
+    argc := f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+
+    // Test with Column not ColumnDef
+    c := &Column{
+        def: cd,
+    }
+    f = c.Sum()
+
+    s = f.Size()
+    assert.Equal(expLen, s)
+
+    argc = f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, expArgCount)
+    b = make([]byte, s)
+    written, numArgs = f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncAvg(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    f := Avg(cd)
+
+    exp := "AVG(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := f.Size()
+    assert.Equal(expLen, s)
+
+    argc := f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestFuncAvgColumn(t *testing.T) {
+    assert := assert.New(t)
+
+    td := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    cd := &ColumnDef{
+        name: "created_on",
+        table: td,
+    }
+
+    f := cd.Avg()
+
+    exp := "AVG(created_on)"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := f.Size()
+    assert.Equal(expLen, s)
+
+    argc := f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+
+    // Test with Column not ColumnDef
+    c := &Column{
+        def: cd,
+    }
+    f = c.Avg()
+
+    s = f.Size()
+    assert.Equal(expLen, s)
+
+    argc = f.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args = make([]interface{}, expArgCount)
+    b = make([]byte, s)
+    written, numArgs = f.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}

--- a/symbol.go
+++ b/symbol.go
@@ -1,6 +1,7 @@
 package sqlb
 
 type Symbol int
+type scanInfo []Symbol
 
 const (
     SYM_ELEMENT = iota // Marker for an element that self-scans into the SQL buffer
@@ -23,6 +24,8 @@ const (
     SYM_ORDER_BY
     SYM_DESC
     SYM_GROUP_BY
+    SYM_MAX
+    SYM_MIN
 )
 
 var (
@@ -46,5 +49,7 @@ var (
         SYM_ORDER_BY: []byte(" ORDER BY "),
         SYM_DESC: []byte(" DESC"),
         SYM_GROUP_BY: []byte(" GROUP BY "),
+        SYM_MAX: []byte("MAX("),
+        SYM_MIN: []byte("MIN("),
     }
 )

--- a/symbol.go
+++ b/symbol.go
@@ -26,6 +26,8 @@ const (
     SYM_GROUP_BY
     SYM_MAX
     SYM_MIN
+    SYM_SUM
+    SYM_AVG
 )
 
 var (
@@ -51,5 +53,7 @@ var (
         SYM_GROUP_BY: []byte(" GROUP BY "),
         SYM_MAX: []byte("MAX("),
         SYM_MIN: []byte("MIN("),
+        SYM_SUM: []byte("SUM("),
+        SYM_AVG: []byte("AVG("),
     }
 )


### PR DESCRIPTION
Users may now use the `MAX()`, `MIN()`, `SUM()`, and `AVG()` SQL functions, either as a top-level library function or as like-named methods on `Column` or `ColumnDef` structs:

```go
users := meta.Table("users")

createdOnCol := users.Column("created_on")

sel1 := Select(Max(createdOnCol).As("max_created_on"))
sel2 := Select(createdOnCol.Max().As("max_created_on"))

// sel1.String() == sel2.String() == "SELECT MAX(created_on) AS max_created_on FROM users"
```

Issue #24