### PR TITLE
Add support for SELECT ... FROM t1 JOIN t2 ON ...

### DIFF
--- a/column.go
+++ b/column.go
@@ -10,6 +10,16 @@ type Column struct {
     tbl *Table
 }
 
+func (c *Column) projectionId() uint64 {
+    if c.alias != "" {
+        args := c.tbl.idParts()
+        args = append(args, c.alias)
+        return toId(args...)
+    }
+    args := c.cdef.idParts()
+    return toId(args...)
+}
+
 func (c *Column) Column() *Column {
     return c
 }
@@ -65,6 +75,16 @@ func isColumn(el Element) bool {
 type ColumnDef struct {
     name string
     tdef *TableDef
+}
+
+func (cd *ColumnDef) projectionId() uint64 {
+    args := cd.tdef.idParts()
+    args = append(args, cd.name)
+    return toId(args...)
+}
+
+func (cd *ColumnDef) idParts() []string {
+    return []string{cd.name, cd.tdef.schema, cd.tdef.name}
 }
 
 func (cd *ColumnDef) Column() *Column {

--- a/function.go
+++ b/function.go
@@ -1,5 +1,9 @@
 package sqlb
 
+import (
+    "fmt"
+)
+
 type funcId int
 
 const (
@@ -32,6 +36,12 @@ type sqlFunc struct {
     alias string
     scanInfo scanInfo
     elements []Element
+}
+
+func (f *sqlFunc) projectionId() uint64 {
+    // Each construction of a function is unique, so here we cheat and just
+    // return the hash of the struct's address in memory
+    return toId(fmt.Sprintf("%p", f))
 }
 
 func (f *sqlFunc) Alias(alias string) {

--- a/join.go
+++ b/join.go
@@ -54,3 +54,10 @@ func (j *JoinClause) Scan(b []byte, args []interface{}) (int, int) {
     }
     return bw, ac
 }
+
+func (j *JoinClause) On(onExprs ...*Expression) *JoinClause {
+    for _, onExpr := range onExprs {
+        j.onExprs = append(j.onExprs, onExpr)
+    }
+    return j
+}

--- a/join.go
+++ b/join.go
@@ -1,0 +1,56 @@
+package sqlb
+
+type joinType int
+
+const (
+    JOIN_INNER joinType = iota
+)
+
+type JoinClause struct {
+    joinType joinType
+    left *Table
+    right *Table
+    onExprs []*Expression
+}
+
+func (j *JoinClause) ArgCount() int {
+    argc := 0
+    for _, onExpr := range j.onExprs {
+        argc += onExpr.ArgCount()
+    }
+    return argc
+}
+
+func (j *JoinClause) Size() int {
+    size := len(Symbols[SYM_JOIN])
+    size += j.right.Size()
+    nonExprs := len(j.onExprs)
+    if nonExprs > 0 {
+        size += len(Symbols[SYM_ON])
+        size += len(Symbols[SYM_AND]) * (nonExprs - 1)
+        for _, onExpr := range j.onExprs {
+            size += onExpr.Size()
+        }
+    }
+    return size
+}
+
+func (j *JoinClause) Scan(b []byte, args []interface{}) (int, int) {
+    var bw, ac int
+    bw += copy(b[bw:], Symbols[SYM_JOIN])
+    pbw, pac := j.right.Scan(b[bw:], args)
+    bw += pbw
+    ac += pac
+    if len(j.onExprs) > 0 {
+        bw += copy(b[bw:], Symbols[SYM_ON])
+        for x, onExpr := range j.onExprs {
+            if x > 0 {
+                bw += copy(b[bw:], Symbols[SYM_AND])
+            }
+            fbw, fac := onExpr.Scan(b[bw:], args[ac:])
+            bw += fbw
+            ac += fac
+        }
+    }
+    return bw, ac
+}

--- a/join.go
+++ b/join.go
@@ -8,8 +8,8 @@ const (
 
 type JoinClause struct {
     joinType joinType
-    left *Table
-    right *Table
+    left Selection
+    right Selection
     onExprs []*Expression
 }
 
@@ -60,4 +60,8 @@ func (j *JoinClause) On(onExprs ...*Expression) *JoinClause {
         j.onExprs = append(j.onExprs, onExpr)
     }
     return j
+}
+
+func Join(left Selection, right Selection, onExpr ...*Expression) *JoinClause {
+    return &JoinClause{left: left, right: right, onExprs: onExpr}
 }

--- a/join_test.go
+++ b/join_test.go
@@ -1,0 +1,145 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+var (
+    users = &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    colUserId = &ColumnDef{
+        name: "id",
+        tdef: users,
+    }
+
+    colUserName = &ColumnDef{
+        name: "name",
+        tdef: users,
+    }
+
+    articles = &TableDef{
+        name: "articles",
+        schema: "test",
+    }
+
+    colArticleId = &ColumnDef{
+        name: "id",
+        tdef: articles,
+    }
+
+    colArticleAuthor = &ColumnDef{
+        name: "author",
+        tdef: articles,
+    }
+)
+
+func init() {
+    users.cdefs = []*ColumnDef{colUserId, colUserName}
+    articles.cdefs = []*ColumnDef{colArticleId, colArticleAuthor}
+}
+
+func TestJoinClauseInnerOnEqualSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    j := &JoinClause{
+        left: articles.Table(),
+        right: users.Table(),
+        onExprs: []*Expression{
+            Equal(colArticleAuthor, colUserId),
+        },
+    }
+
+    exp := " JOIN users ON author = id"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := j.Size()
+    assert.Equal(expLen, s)
+
+    argc := j.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := j.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestJoinClauseAliasedInnerOnEqualSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    atbl := articles.Table().As("a")
+    utbl := users.Table().As("u")
+
+    aliasAuthorCol := atbl.Column("author")
+    assert.NotNil(aliasAuthorCol)
+
+    aliasIdCol := utbl.Column("id")
+    assert.NotNil(aliasIdCol)
+
+    j := &JoinClause{
+        left: atbl,
+        right: utbl,
+        onExprs: []*Expression{
+            Equal(aliasAuthorCol, aliasIdCol),
+        },
+    }
+
+    exp := " JOIN users AS u ON a.author = u.id"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := j.Size()
+    assert.Equal(expLen, s)
+
+    argc := j.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := j.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
+func TestJoinClauseInnerOnEqualMulti(t *testing.T) {
+    assert := assert.New(t)
+
+    j := &JoinClause{
+        left: articles.Table(),
+        right: users.Table(),
+        onExprs: []*Expression{
+            Equal(colArticleAuthor, colUserId),
+            Equal(colUserName, "foo"),
+        },
+    }
+
+    exp := " JOIN users ON author = id AND name = ?"
+    expLen := len(exp)
+    expArgCount := 1
+
+    s := j.Size()
+    assert.Equal(expLen, s)
+
+    argc := j.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := j.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+    assert.Equal("foo", args[0])
+}

--- a/join_test.go
+++ b/join_test.go
@@ -73,6 +73,34 @@ func TestJoinClauseInnerOnEqualSingle(t *testing.T) {
     assert.Equal(expArgCount, numArgs)
 }
 
+func TestJoinClauseOnMethod(t *testing.T) {
+    assert := assert.New(t)
+
+    j := &JoinClause{
+        left: articles.Table(),
+        right: users.Table(),
+    }
+    j.On(Equal(colArticleAuthor, colUserId))
+
+    exp := " JOIN users ON author = id"
+    expLen := len(exp)
+    expArgCount := 0
+
+    s := j.Size()
+    assert.Equal(expLen, s)
+
+    argc := j.ArgCount()
+    assert.Equal(expArgCount, argc)
+
+    args := make([]interface{}, expArgCount)
+    b := make([]byte, s)
+    written, numArgs := j.Scan(b, args)
+
+    assert.Equal(s, written)
+    assert.Equal(exp, string(b))
+    assert.Equal(expArgCount, numArgs)
+}
+
 func TestJoinClauseAliasedInnerOnEqualSingle(t *testing.T) {
     assert := assert.New(t)
 

--- a/select.go
+++ b/select.go
@@ -1,7 +1,19 @@
 package sqlb
 
-// A Selection is something that produces rows. A table, view, subselect, etc
+// A Projection is something that produces a scalar value. A column, column
+// definition, function, etc.
+type Projection interface {
+    projectionId() uint64
+    // Projections must also implement Element
+    Size() int
+    ArgCount() int
+    Scan([]byte, []interface{}) (int, int)
+}
+
+// A Selection is something that produces rows. A table, table definition,
+// view, subselect, etc
 type Selection interface {
+    projections() []Projection
     selectionId() uint64
     // Selections must also implement Element
     Size() int
@@ -240,13 +252,13 @@ func Select(items ...Element) *SelectClause {
                 }
             case *Table:
                 v := item.(*Table)
-                for _, cd := range v.tdef.ColumnDefs() {
+                for _, cd := range v.tdef.projections() {
                     res.projected.elements = append(res.projected.elements, cd)
                 }
                 selectionMap[v.selectionId()] = v
             case *TableDef:
                 v := item.(*TableDef)
-                for _, cd := range v.ColumnDefs() {
+                for _, cd := range v.projections() {
                     res.projected.elements = append(res.projected.elements, cd)
                 }
                 selectionMap[v.selectionId()] = v

--- a/select_test.go
+++ b/select_test.go
@@ -522,3 +522,49 @@ func TestSelectGroupOrderLimit(t *testing.T) {
     assert.Equal(expArgCount, sel.ArgCount())
     assert.Equal(exp, sel.String())
 }
+
+func TestSelectJoinSingle(t *testing.T) {
+    assert := assert.New(t)
+
+    users := &TableDef{
+        name: "users",
+        schema: "test",
+    }
+
+    colUserId := &ColumnDef{
+        name: "id",
+        tdef: users,
+    }
+
+    users.cdefs = []*ColumnDef{colUserId}
+
+    articles := &TableDef{
+        name: "articles",
+        schema: "test",
+    }
+
+    colArticleAuthor := &ColumnDef{
+        name: "author",
+        tdef: articles,
+    }
+
+    articles.cdefs = []*ColumnDef{colArticleAuthor}
+
+    j := &JoinClause{
+        left: users,
+        right: articles,
+        onExprs: []*Expression{
+            Equal(colUserId, colArticleAuthor),
+        },
+    }
+
+    sel := Select(j)
+
+    exp := "SELECT id FROM users JOIN articles ON id = author"
+    expLen := len(exp)
+    expArgCount := 0
+
+    assert.Equal(expLen, sel.Size())
+    assert.Equal(expArgCount, sel.ArgCount())
+    assert.Equal(exp, sel.String())
+}

--- a/symbol.go
+++ b/symbol.go
@@ -11,20 +11,22 @@ const (
     SYM_COMMA_WS
     SYM_SELECT
     SYM_FROM
+    SYM_JOIN
+    SYM_ON
+    SYM_WHERE
+    SYM_GROUP_BY
+    SYM_ORDER_BY
+    SYM_DESC
+    SYM_LIMIT
+    SYM_OFFSET
     SYM_LPAREN
     SYM_RPAREN
     SYM_IN
-    SYM_WHERE
     SYM_AND
     SYM_OR
     SYM_EQUAL
     SYM_NEQUAL
     SYM_BETWEEN
-    SYM_LIMIT
-    SYM_OFFSET
-    SYM_ORDER_BY
-    SYM_DESC
-    SYM_GROUP_BY
     SYM_MAX
     SYM_MIN
     SYM_SUM
@@ -39,20 +41,22 @@ var (
         SYM_COMMA_WS: []byte(", "),
         SYM_SELECT: []byte("SELECT "),
         SYM_FROM: []byte(" FROM "),
+        SYM_JOIN: []byte(" JOIN "),
+        SYM_ON: []byte(" ON "),
+        SYM_WHERE: []byte(" WHERE "),
+        SYM_GROUP_BY: []byte(" GROUP BY "),
+        SYM_ORDER_BY: []byte(" ORDER BY "),
+        SYM_DESC: []byte(" DESC"),
+        SYM_LIMIT: []byte(" LIMIT "),
+        SYM_OFFSET: []byte(" OFFSET "),
         SYM_LPAREN: []byte("("),
         SYM_RPAREN: []byte(")"),
         SYM_IN: []byte(" IN ("),
-        SYM_WHERE: []byte(" WHERE "),
         SYM_AND: []byte(" AND "),
         SYM_OR: []byte(" OR "),
         SYM_EQUAL: []byte(" = "),
         SYM_NEQUAL: []byte(" != "),
         SYM_BETWEEN: []byte(" BETWEEN "),
-        SYM_LIMIT: []byte(" LIMIT "),
-        SYM_OFFSET: []byte(" OFFSET "),
-        SYM_ORDER_BY: []byte(" ORDER BY "),
-        SYM_DESC: []byte(" DESC"),
-        SYM_GROUP_BY: []byte(" GROUP BY "),
         SYM_MAX: []byte("MAX("),
         SYM_MIN: []byte("MIN("),
         SYM_SUM: []byte("SUM("),

--- a/table.go
+++ b/table.go
@@ -12,8 +12,15 @@ func (t *Table) selectionId() uint64 {
     return t.tdef.selectionId()
 }
 
+func (t *Table) idParts() []string {
+    if t.alias != "" {
+        return []string{t.alias}
+    }
+    return t.tdef.idParts()
+}
+
 func (t *Table) Column(name string) *Column {
-    for _, cdef := range t.tdef.ColumnDefs() {
+    for _, cdef := range t.tdef.cdefs {
         if name == cdef.name {
             return &Column{
                 tbl: t,
@@ -24,10 +31,10 @@ func (t *Table) Column(name string) *Column {
     return nil
 }
 
-func (t *Table) Columns() []*Column {
-    cdefs := t.tdef.ColumnDefs()
+func (t *Table) projections() []Projection {
+    cdefs := t.tdef.cdefs
     ncols := len(cdefs)
-    cols := make([]*Column, ncols)
+    cols := make([]Projection, ncols)
     for x := 0; x < ncols; x++ {
         cols[x] = &Column{
             tbl: t,
@@ -77,6 +84,10 @@ func (td *TableDef) selectionId() uint64 {
     return toId(td.schema, td.name)
 }
 
+func (td *TableDef) idParts() []string {
+    return []string{td.schema, td.name}
+}
+
 func (td *TableDef) Table() *Table {
     return &Table{tdef: td}
 }
@@ -112,6 +123,10 @@ func (td *TableDef) Column(name string) *Column {
     return nil
 }
 
-func (td *TableDef) ColumnDefs() []*ColumnDef {
-    return td.cdefs
+func (td *TableDef) projections() []Projection {
+    res := make([]Projection, len(td.cdefs))
+    for x, cdef := range td.cdefs {
+        res[x] = cdef
+    }
+    return res
 }

--- a/table.go
+++ b/table.go
@@ -5,11 +5,11 @@ type Table struct {
     tdef *TableDef
 }
 
-func (t *Table) id() uint64 {
+func (t *Table) selectionId() uint64 {
     if t.alias != "" {
         return toId(t.alias)
     }
-    return t.tdef.id()
+    return t.tdef.selectionId()
 }
 
 func (t *Table) Column(name string) *Column {
@@ -73,7 +73,7 @@ type TableDef struct {
     cdefs []*ColumnDef
 }
 
-func (td *TableDef) id() uint64 {
+func (td *TableDef) selectionId() uint64 {
     return toId(td.schema, td.name)
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -75,7 +75,7 @@ func TestTableColumnDefs(t *testing.T) {
     }
     td.cdefs = cdefs
 
-    defs := td.ColumnDefs()
+    defs := td.cdefs
 
     assert.Equal(2, len(defs))
     for _, def := range defs {


### PR DESCRIPTION
Initial support for adding JOIN clauses to the SelectClause struct.
Currently does not properly handle >1 join arguments to Select()
properly but this is as good a place to stop as any because we're going
to need to fix the bug in Issue #28 before going much further in join
support.

Issue #23