### PR TITLE
Always use qualified column names

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -24,7 +24,7 @@ func TestColumn(t *testing.T) {
         tbl: td.Table(),
     }
 
-    exp := "name"
+    exp := "users.name"
     expLen := len(exp)
     s := c.Size()
     assert.Equal(expLen, s)
@@ -81,7 +81,7 @@ func TestColumnDefSorts(t *testing.T) {
 
     sc := cd.Asc()
 
-    exp := "name"
+    exp := "users.name"
     expLen := len(exp)
     s := sc.Size()
     assert.Equal(expLen, s)
@@ -94,7 +94,7 @@ func TestColumnDefSorts(t *testing.T) {
 
     sc = cd.Desc()
 
-    exp = "name DESC"
+    exp = "users.name DESC"
     expLen = len(exp)
     s = sc.Size()
     assert.Equal(expLen, s)
@@ -126,7 +126,7 @@ func TestColumnSorts(t *testing.T) {
 
     sc := c.Asc()
 
-    exp := "name"
+    exp := "users.name"
     expLen := len(exp)
     s := sc.Size()
     assert.Equal(expLen, s)
@@ -139,7 +139,7 @@ func TestColumnSorts(t *testing.T) {
 
     sc = c.Desc()
 
-    exp = "name DESC"
+    exp = "users.name DESC"
     expLen = len(exp)
     s = sc.Size()
     assert.Equal(expLen, s)
@@ -170,7 +170,7 @@ func TestColumnAlias(t *testing.T) {
         alias: "user_name",
     }
 
-    exp := "name AS user_name"
+    exp := "users.name AS user_name"
     expLen := len(exp)
     s := c.Size()
     assert.Equal(expLen, s)

--- a/expression_test.go
+++ b/expression_test.go
@@ -31,7 +31,7 @@ func TestExpressionEqual(t *testing.T) {
         elements: []Element{c, val},
     }
 
-    exp := "name = ?"
+    exp := "users.name = ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -59,7 +59,7 @@ func TestExpressionEqual(t *testing.T) {
         elements: []Element{val, c},
     }
 
-    exp = "? = name"
+    exp = "? = users.name"
     expLen = len(exp)
     expArgCount = 1
 
@@ -99,7 +99,7 @@ func TestEqualFuncValue(t *testing.T) {
 
     eq := Equal(c, "foo")
 
-    exp := "name = ?"
+    exp := "users.name = ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -154,7 +154,7 @@ func TestEqualFuncTwoElements(t *testing.T) {
 
     eq := Equal(c1, c2)
 
-    exp := "id = author"
+    exp := "users.id = articles.author"
     expLen := len(exp)
     expArgCount := 0
 
@@ -179,7 +179,7 @@ func TestEqualFuncTwoElements(t *testing.T) {
 
     erev := Equal(c2, c1)
 
-    exp = "author = id"
+    exp = "articles.author = users.id"
     expLen = len(exp)
     expArgCount = 0
 
@@ -224,7 +224,7 @@ func TestExpressionNotEqual(t *testing.T) {
         elements: []Element{c, val},
     }
 
-    exp := "name != ?"
+    exp := "users.name != ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -264,7 +264,7 @@ func TestNotEqualFuncValue(t *testing.T) {
 
     eq := NotEqual(c, "foo")
 
-    exp := "name != ?"
+    exp := "users.name != ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -319,7 +319,7 @@ func TestNotEqualFuncTwoElements(t *testing.T) {
 
     eq := NotEqual(c1, c2)
 
-    exp := "id != author"
+    exp := "users.id != articles.author"
     expLen := len(exp)
     expArgCount := 0
 
@@ -344,7 +344,7 @@ func TestNotEqualFuncTwoElements(t *testing.T) {
 
     erev := NotEqual(c2, c1)
 
-    exp = "author != id"
+    exp = "articles.author != users.id"
     expLen = len(exp)
     expArgCount = 0
 
@@ -384,7 +384,7 @@ func TestInSingle(t *testing.T) {
 
     e := In(c, "foo")
 
-    exp := "name IN (?)"
+    exp := "users.name IN (?)"
     expLen := len(exp)
     expArgCount := 1
 
@@ -424,7 +424,7 @@ func TestInMulti(t *testing.T) {
 
     e := In(c, "foo", "bar", 1)
 
-    exp := "name IN (?, ?, ?)"
+    exp := "users.name IN (?, ?, ?)"
     expLen := len(exp)
     expArgCount := 3
 
@@ -473,7 +473,7 @@ func TestAnd(t *testing.T) {
     }
     e := And(ea, eb)
 
-    exp := "name != ? AND name != ?"
+    exp := "users.name != ? AND users.name != ?"
     expLen := len(exp)
     expArgCount := 2
 
@@ -524,7 +524,7 @@ func TestOr(t *testing.T) {
     }
     e := Or(ea, eb)
 
-    exp := "name = ? OR name = ?"
+    exp := "users.name = ? OR users.name = ?"
     expLen := len(exp)
     expArgCount := 2
 

--- a/function_test.go
+++ b/function_test.go
@@ -21,7 +21,7 @@ func TestFuncWithAlias(t *testing.T) {
 
     m := Max(cd).As("max_created_on")
 
-    exp := "MAX(created_on) AS max_created_on"
+    exp := "MAX(users.created_on) AS max_created_on"
     expLen := len(exp)
     expArgCount := 0
 
@@ -55,7 +55,7 @@ func TestFuncMax(t *testing.T) {
 
     m := Max(cd)
 
-    exp := "MAX(created_on)"
+    exp := "MAX(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -89,7 +89,7 @@ func TestFuncMaxColumn(t *testing.T) {
 
     m := cd.Max()
 
-    exp := "MAX(created_on)"
+    exp := "MAX(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -144,7 +144,7 @@ func TestFuncMin(t *testing.T) {
 
     m := Min(cd)
 
-    exp := "MIN(created_on)"
+    exp := "MIN(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -178,7 +178,7 @@ func TestFuncMinColumn(t *testing.T) {
 
     m := cd.Min()
 
-    exp := "MIN(created_on)"
+    exp := "MIN(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -233,7 +233,7 @@ func TestFuncSum(t *testing.T) {
 
     f := Sum(cd)
 
-    exp := "SUM(created_on)"
+    exp := "SUM(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -267,7 +267,7 @@ func TestFuncSumColumn(t *testing.T) {
 
     f := cd.Sum()
 
-    exp := "SUM(created_on)"
+    exp := "SUM(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -322,7 +322,7 @@ func TestFuncAvg(t *testing.T) {
 
     f := Avg(cd)
 
-    exp := "AVG(created_on)"
+    exp := "AVG(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 
@@ -356,7 +356,7 @@ func TestFuncAvgColumn(t *testing.T) {
 
     f := cd.Avg()
 
-    exp := "AVG(created_on)"
+    exp := "AVG(users.created_on)"
     expLen := len(exp)
     expArgCount := 0
 

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -25,7 +25,7 @@ func TestGroupByClauseSingle(t *testing.T) {
         },
     }
 
-    exp := " GROUP BY name"
+    exp := " GROUP BY users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -68,7 +68,7 @@ func TestGroupByClauseMulti(t *testing.T) {
         },
     }
 
-    exp := " GROUP BY name, email"
+    exp := " GROUP BY users.name, users.email"
     expLen := len(exp)
     expArgCount := 0
 

--- a/join_test.go
+++ b/join_test.go
@@ -57,7 +57,7 @@ func TestJoinFuncGenerics(t *testing.T) {
     }
 
     for _, j := range joins {
-        exp := " JOIN users ON author = id"
+        exp := " JOIN users ON articles.author = users.id"
         expLen := len(exp)
         expArgCount := 0
 
@@ -88,7 +88,7 @@ func TestJoinClauseInnerOnEqualSingle(t *testing.T) {
         },
     }
 
-    exp := " JOIN users ON author = id"
+    exp := " JOIN users ON articles.author = users.id"
     expLen := len(exp)
     expArgCount := 0
 
@@ -116,7 +116,7 @@ func TestJoinClauseOnMethod(t *testing.T) {
     }
     j.On(Equal(colArticleAuthor, colUserId))
 
-    exp := " JOIN users ON author = id"
+    exp := " JOIN users ON articles.author = users.id"
     expLen := len(exp)
     expArgCount := 0
 
@@ -186,7 +186,7 @@ func TestJoinClauseInnerOnEqualMulti(t *testing.T) {
         },
     }
 
-    exp := " JOIN users ON author = id AND name = ?"
+    exp := " JOIN users ON articles.author = users.id AND users.name = ?"
     expLen := len(exp)
     expArgCount := 1
 

--- a/list_test.go
+++ b/list_test.go
@@ -26,7 +26,7 @@ func TestListSingle(t *testing.T) {
 
     cl := &List{elements: []Element{c}}
 
-    exp := "name"
+    exp := "users.name"
     expLen := len(exp)
     s := cl.Size()
     assert.Equal(expLen, s)
@@ -68,7 +68,7 @@ func TestListMulti(t *testing.T) {
 
     cl := &List{elements: []Element{c1, c2}}
 
-    exp := "name, email"
+    exp := "users.name, users.email"
     expLen := len(exp)
     s := cl.Size()
     assert.Equal(expLen, s)

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -27,7 +27,7 @@ func TestOrderByClauseSingleAsc(t *testing.T) {
         },
     }
 
-    exp := " ORDER BY name"
+    exp := " ORDER BY users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -67,7 +67,7 @@ func TestOrderByClauseSingleDesc(t *testing.T) {
         },
     }
 
-    exp := " ORDER BY name DESC"
+    exp := " ORDER BY users.name DESC"
     expLen := len(exp)
     expArgCount := 0
 
@@ -113,7 +113,7 @@ func TestOrderByClauseMultiAsc(t *testing.T) {
         },
     }
 
-    exp := " ORDER BY name, email"
+    exp := " ORDER BY users.name, users.email"
     expLen := len(exp)
     expArgCount := 0
 
@@ -159,7 +159,7 @@ func TestOrderByClauseMultiAscDesc(t *testing.T) {
         },
     }
 
-    exp := " ORDER BY name, email DESC"
+    exp := " ORDER BY users.name, users.email DESC"
     expLen := len(exp)
     expArgCount := 0
 

--- a/select_test.go
+++ b/select_test.go
@@ -26,7 +26,7 @@ func TestSelectSingleColumn(t *testing.T) {
 
     sel := Select(c)
 
-    exp := "SELECT name FROM users"
+    exp := "SELECT users.name FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.Size())
@@ -90,7 +90,7 @@ func TestSelectMultiColumnsSingleTable(t *testing.T) {
 
     sel := Select(c1, c2)
 
-    exp := "SELECT name, email FROM users"
+    exp := "SELECT users.name, users.email FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.Size())
@@ -112,7 +112,7 @@ func TestSelectFromColumnDef(t *testing.T) {
 
     sel := Select(cd)
 
-    exp := "SELECT name FROM users"
+    exp := "SELECT users.name FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.Size())
@@ -144,7 +144,7 @@ func TestSelectFromColumnDefAndColumn(t *testing.T) {
 
     sel := Select(cd1, c2)
 
-    exp := "SELECT name, email FROM users"
+    exp := "SELECT users.name, users.email FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.Size())
@@ -173,7 +173,7 @@ func TestSelectFromTableDef(t *testing.T) {
 
     sel := Select(td)
 
-    exp := "SELECT name, email FROM users"
+    exp := "SELECT users.name, users.email FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.Size())
@@ -195,7 +195,7 @@ func TestWhereSingleEqual(t *testing.T) {
 
     sel := Select(cd).Where(Equal(cd, "foo"))
 
-    exp := "SELECT name FROM users WHERE name = ?"
+    exp := "SELECT users.name FROM users WHERE users.name = ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -219,7 +219,7 @@ func TestWhereSingleAnd(t *testing.T) {
 
     sel := Select(cd).Where(And(NotEqual(cd, "foo"), NotEqual(cd, "bar")))
 
-    exp := "SELECT name FROM users WHERE name != ? AND name != ?"
+    exp := "SELECT users.name FROM users WHERE users.name != ? AND users.name != ?"
     expLen := len(exp)
     expArgCount := 2
 
@@ -243,7 +243,7 @@ func TestWhereSingleIn(t *testing.T) {
 
     sel := Select(cd).Where(In(cd, "foo", "bar"))
 
-    exp := "SELECT name FROM users WHERE name IN (?, ?)"
+    exp := "SELECT users.name FROM users WHERE users.name IN (?, ?)"
     expLen := len(exp)
     expArgCount := 2
 
@@ -268,7 +268,7 @@ func TestWhereMultiNotEqual(t *testing.T) {
     sel := Select(cd).Where(NotEqual(cd, "foo"))
     sel = sel.Where(NotEqual(cd, "bar"))
 
-    exp := "SELECT name FROM users WHERE name != ? AND name != ?"
+    exp := "SELECT users.name FROM users WHERE users.name != ? AND users.name != ?"
     expLen := len(exp)
     expArgCount := 2
 
@@ -297,7 +297,7 @@ func TestWhereMultiInAndEqual(t *testing.T) {
 
     sel := Select(cd1).Where(And(In(cd1, "foo", "bar"), Equal(cd2, 1)))
 
-    exp := "SELECT name FROM users WHERE name IN (?, ?) AND is_author = ?"
+    exp := "SELECT users.name FROM users WHERE users.name IN (?, ?) AND users.is_author = ?"
     expLen := len(exp)
     expArgCount := 3
 
@@ -326,7 +326,7 @@ func TestSelectLimit(t *testing.T) {
 
     sel := Select(c).Limit(10)
 
-    exp := "SELECT name FROM users LIMIT ?"
+    exp := "SELECT users.name FROM users LIMIT ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -355,7 +355,7 @@ func TestSelectLimitWithOffset(t *testing.T) {
 
     sel := Select(c).LimitWithOffset(10, 5)
 
-    exp := "SELECT name FROM users LIMIT ? OFFSET ?"
+    exp := "SELECT users.name FROM users LIMIT ? OFFSET ?"
     expLen := len(exp)
     expArgCount := 2
 
@@ -379,7 +379,7 @@ func TestSelectOrderByAsc(t *testing.T) {
 
     sel := Select(cd).OrderBy(cd.Asc())
 
-    exp := "SELECT name FROM users ORDER BY name"
+    exp := "SELECT users.name FROM users ORDER BY users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -408,7 +408,7 @@ func TestSelectOrderByMultiAscDesc(t *testing.T) {
 
     sel := Select(cd1).OrderBy(cd1.Asc(), cd2.Desc())
 
-    exp := "SELECT name FROM users ORDER BY name, email DESC"
+    exp := "SELECT users.name FROM users ORDER BY users.name, users.email DESC"
     expLen := len(exp)
     expArgCount := 0
 
@@ -432,7 +432,7 @@ func TestSelectStringArgs(t *testing.T) {
 
     sel := Select(cd).Where(In(cd, "foo", "bar"))
 
-    expStr := "SELECT name FROM users WHERE name IN (?, ?)"
+    expStr := "SELECT users.name FROM users WHERE users.name IN (?, ?)"
     expLen := len(expStr)
     expArgCount := 2
     expArgs := []interface{}{"foo", "bar"}
@@ -461,7 +461,7 @@ func TestSelectGroupByAsc(t *testing.T) {
 
     sel := Select(cd).GroupBy(cd)
 
-    exp := "SELECT name FROM users GROUP BY name"
+    exp := "SELECT users.name FROM users GROUP BY users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -490,7 +490,7 @@ func TestSelectGroupByMultiAscDesc(t *testing.T) {
 
     sel := Select(cd1).GroupBy(cd1, cd2)
 
-    exp := "SELECT name FROM users GROUP BY name, email"
+    exp := "SELECT users.name FROM users GROUP BY users.name, users.email"
     expLen := len(exp)
     expArgCount := 0
 
@@ -514,7 +514,7 @@ func TestSelectGroupOrderLimit(t *testing.T) {
 
     sel := Select(cd).GroupBy(cd).OrderBy(cd.Desc()).Limit(10)
 
-    exp := "SELECT name FROM users GROUP BY name ORDER BY name DESC LIMIT ?"
+    exp := "SELECT users.name FROM users GROUP BY users.name ORDER BY users.name DESC LIMIT ?"
     expLen := len(exp)
     expArgCount := 1
 
@@ -560,7 +560,7 @@ func TestSelectJoinSingle(t *testing.T) {
 
     sel := Select(j)
 
-    exp := "SELECT id FROM users JOIN articles ON id = author"
+    exp := "SELECT users.id FROM users JOIN articles ON users.id = articles.author"
     expLen := len(exp)
     expArgCount := 0
 


### PR DESCRIPTION
Instead of trying to switch qualified name output based on how many
selections are in a SelectClause, it's just more efficient, consistent
and safe to use qualified names always.

Closes Issue #28