### PR TITLE
Rework how TableDef and Meta are related

### DIFF
--- a/alias_test.go
+++ b/alias_test.go
@@ -9,19 +9,9 @@ import (
 func TestAsTemplated(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     assert.Equal("", c.alias)
@@ -38,13 +28,8 @@ func TestAsTemplated(t *testing.T) {
 func TestAsMethod(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     t1 := &Table{
-        tdef: td,
+        tdef: users,
     }
 
     assert.Equal("", t1.alias)
@@ -53,14 +38,9 @@ func TestAsMethod(t *testing.T) {
 
     assert.Equal("t", t1.alias)
 
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     assert.Equal("", c.alias)

--- a/column.go
+++ b/column.go
@@ -89,7 +89,7 @@ func (cd *ColumnDef) projectionId() uint64 {
 }
 
 func (cd *ColumnDef) idParts() []string {
-    return []string{cd.name, cd.tdef.schema, cd.tdef.name}
+    return []string{cd.name, cd.tdef.meta.schemaName, cd.tdef.name}
 }
 
 func (cd *ColumnDef) Column() *Column {

--- a/column_test.go
+++ b/column_test.go
@@ -9,19 +9,9 @@ import (
 func TestColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     exp := "users.name"
@@ -39,19 +29,9 @@ func TestColumn(t *testing.T) {
 func TestColumnWithTableAlias(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.As("u"),
+        cdef: colUserName,
+        tbl: users.As("u"),
     }
 
     exp := "u.name"
@@ -69,17 +49,7 @@ func TestColumnWithTableAlias(t *testing.T) {
 func TestColumnDefSorts(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sc := cd.Asc()
+    sc := colUserName.Asc()
 
     exp := "users.name"
     expLen := len(exp)
@@ -92,7 +62,7 @@ func TestColumnDefSorts(t *testing.T) {
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
 
-    sc = cd.Desc()
+    sc = colUserName.Desc()
 
     exp = "users.name DESC"
     expLen = len(exp)
@@ -109,19 +79,9 @@ func TestColumnDefSorts(t *testing.T) {
 func TestColumnSorts(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     sc := c.Asc()
@@ -154,19 +114,9 @@ func TestColumnSorts(t *testing.T) {
 func TestColumnAlias(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
         alias: "user_name",
     }
 
@@ -185,17 +135,7 @@ func TestColumnAlias(t *testing.T) {
 func TestColumnAs(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    c := cd.As("n")
+    c := colUserName.As("n")
     assert.Equal("n", c.alias)
-    assert.Equal(cd, c.cdef)
+    assert.Equal(colUserName, c.cdef)
 }

--- a/expression_test.go
+++ b/expression_test.go
@@ -9,19 +9,9 @@ import (
 func TestExpressionEqual(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     val := &Value{value: "foo"}
@@ -82,19 +72,9 @@ func TestExpressionEqual(t *testing.T) {
 func TestEqualFuncValue(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     eq := Equal(c, "foo")
@@ -122,33 +102,13 @@ func TestEqualFuncValue(t *testing.T) {
 func TestEqualFuncTwoelements(t *testing.T) {
     assert := assert.New(t)
 
-    users := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    userId := &ColumnDef{
-        name: "id",
-        tdef: users,
-    }
-
     c1 := &Column{
-        cdef: userId,
+        cdef: colUserId,
         tbl: users.Table(),
     }
 
-    articles := &TableDef{
-        name: "articles",
-        schema: "test",
-    }
-
-    author := &ColumnDef{
-        name: "author",
-        tdef: articles,
-    }
-
     c2 := &Column{
-        cdef: author,
+        cdef: colArticleAuthor,
         tbl: articles.Table(),
     }
 
@@ -202,19 +162,9 @@ func TestEqualFuncTwoelements(t *testing.T) {
 func TestExpressionNotEqual(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     val := &Value{value: "foo"}
@@ -247,19 +197,9 @@ func TestExpressionNotEqual(t *testing.T) {
 func TestNotEqualFuncValue(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     eq := NotEqual(c, "foo")
@@ -287,33 +227,13 @@ func TestNotEqualFuncValue(t *testing.T) {
 func TestNotEqualFuncTwoelements(t *testing.T) {
     assert := assert.New(t)
 
-    users := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    userId := &ColumnDef{
-        name: "id",
-        tdef: users,
-    }
-
     c1 := &Column{
-        cdef: userId,
+        cdef: colUserId,
         tbl: users.Table(),
     }
 
-    articles := &TableDef{
-        name: "articles",
-        schema: "test",
-    }
-
-    author := &ColumnDef{
-        name: "author",
-        tdef: articles,
-    }
-
     c2 := &Column{
-        cdef: author,
+        cdef: colArticleAuthor,
         tbl: articles.Table(),
     }
 
@@ -367,19 +287,9 @@ func TestNotEqualFuncTwoelements(t *testing.T) {
 func TestInSingle(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     e := In(c, "foo")
@@ -407,19 +317,9 @@ func TestInSingle(t *testing.T) {
 func TestInMulti(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     e := In(c, "foo", "bar", 1)
@@ -447,19 +347,9 @@ func TestInMulti(t *testing.T) {
 func TestAnd(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     ea := &Expression{
@@ -498,19 +388,9 @@ func TestAnd(t *testing.T) {
 func TestOr(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     ea := &Expression{

--- a/function_test.go
+++ b/function_test.go
@@ -9,14 +9,9 @@ import (
 func TestFuncWithAlias(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     m := Max(cd).As("max_created_on")
@@ -43,14 +38,9 @@ func TestFuncWithAlias(t *testing.T) {
 func TestFuncMax(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     m := Max(cd)
@@ -77,14 +67,9 @@ func TestFuncMax(t *testing.T) {
 func TestFuncMaxColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     m := cd.Max()
@@ -110,7 +95,7 @@ func TestFuncMaxColumn(t *testing.T) {
     // Test with Column not ColumnDef
     c := &Column{
         cdef: cd,
-        tbl: td.Table(),
+        tbl: users.Table(),
     }
     m = c.Max()
 
@@ -132,14 +117,9 @@ func TestFuncMaxColumn(t *testing.T) {
 func TestFuncMin(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     m := Min(cd)
@@ -166,14 +146,9 @@ func TestFuncMin(t *testing.T) {
 func TestFuncMinColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     m := cd.Min()
@@ -199,7 +174,7 @@ func TestFuncMinColumn(t *testing.T) {
     // Test with Column not ColumnDef
     c := &Column{
         cdef: cd,
-        tbl: td.Table(),
+        tbl: users.Table(),
     }
     m = c.Min()
 
@@ -221,14 +196,9 @@ func TestFuncMinColumn(t *testing.T) {
 func TestFuncSum(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     f := Sum(cd)
@@ -255,14 +225,9 @@ func TestFuncSum(t *testing.T) {
 func TestFuncSumColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     f := cd.Sum()
@@ -288,7 +253,7 @@ func TestFuncSumColumn(t *testing.T) {
     // Test with Column not ColumnDef
     c := &Column{
         cdef: cd,
-        tbl: td.Table(),
+        tbl: users.Table(),
     }
     f = c.Sum()
 
@@ -310,14 +275,9 @@ func TestFuncSumColumn(t *testing.T) {
 func TestFuncAvg(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     f := Avg(cd)
@@ -344,14 +304,9 @@ func TestFuncAvg(t *testing.T) {
 func TestFuncAvgColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
     cd := &ColumnDef{
         name: "created_on",
-        tdef: td,
+        tdef: users,
     }
 
     f := cd.Avg()
@@ -377,7 +332,7 @@ func TestFuncAvgColumn(t *testing.T) {
     // Test with Column not ColumnDef
     c := &Column{
         cdef: cd,
-        tbl: td.Table(),
+        tbl: users.Table(),
     }
     f = c.Avg()
 

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -9,19 +9,9 @@ import (
 func TestGroupByClauseSingle(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     ob := &GroupByClause{
         cols: &List{
-            elements: []element{cd},
+            elements: []element{colUserName},
         },
     }
 
@@ -47,28 +37,13 @@ func TestGroupByClauseSingle(t *testing.T) {
 func TestGroupByClauseMulti(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
     ob := &GroupByClause{
         cols: &List{
-            elements: []element{cd1, cd2},
+            elements: []element{colUserId, colUserName},
         },
     }
 
-    exp := " GROUP BY users.name, users.email"
+    exp := " GROUP BY users.id, users.name"
     expLen := len(exp)
     expArgCount := 0
 

--- a/join_test.go
+++ b/join_test.go
@@ -7,31 +7,32 @@ import (
 )
 
 var (
-    users = &TableDef{
-        name: "users",
-        schema: "test",
+    meta = &Meta{
+        schemaName: "test",
+        tables: make(map[string]*TableDef, 0),
     }
 
+    users = &TableDef{
+        meta: meta,
+        name: "users",
+    }
     colUserId = &ColumnDef{
         name: "id",
         tdef: users,
     }
-
     colUserName = &ColumnDef{
         name: "name",
         tdef: users,
     }
 
     articles = &TableDef{
+        meta: meta,
         name: "articles",
-        schema: "test",
     }
-
     colArticleId = &ColumnDef{
         name: "id",
         tdef: articles,
     }
-
     colArticleAuthor = &ColumnDef{
         name: "author",
         tdef: articles,
@@ -41,6 +42,8 @@ var (
 func init() {
     users.cdefs = []*ColumnDef{colUserId, colUserName}
     articles.cdefs = []*ColumnDef{colArticleId, colArticleAuthor}
+    meta.tables["users"] = users
+    meta.tables["articles"] = articles
 }
 
 func TestJoinFuncGenerics(t *testing.T) {

--- a/list_test.go
+++ b/list_test.go
@@ -9,19 +9,9 @@ import (
 func TestListSingle(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     cl := &List{elements: []element{c}}
@@ -41,34 +31,19 @@ func TestListSingle(t *testing.T) {
 func TestListMulti(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
     c1 := &Column{
-        cdef: cd1,
-        tbl: td.Table(),
+        cdef: colUserId,
+        tbl: users.Table(),
     }
 
     c2:= &Column{
-        cdef: cd2,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     cl := &List{elements: []element{c1, c2}}
 
-    exp := "users.name, users.email"
+    exp := "users.id, users.name"
     expLen := len(exp)
     s := cl.size()
     assert.Equal(expLen, s)

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -9,20 +9,10 @@ import (
 func TestOrderByClauseSingleAsc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     ob := &OrderByClause{
         cols: &List{
             elements: []element{
-                &SortColumn{el: cd},
+                &SortColumn{el: colUserName},
             },
         },
     }
@@ -49,20 +39,10 @@ func TestOrderByClauseSingleAsc(t *testing.T) {
 func TestOrderByClauseSingleDesc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     ob := &OrderByClause{
         cols: &List{
             elements: []element{
-                &SortColumn{el: cd, desc: true},
+                &SortColumn{el: colUserName, desc: true},
             },
         },
     }
@@ -89,31 +69,16 @@ func TestOrderByClauseSingleDesc(t *testing.T) {
 func TestOrderByClauseMultiAsc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
     ob := &OrderByClause{
         cols: &List{
             elements: []element{
-                &SortColumn{el: cd1},
-                &SortColumn{el: cd2},
+                &SortColumn{el: colUserId},
+                &SortColumn{el: colUserName},
             },
         },
     }
 
-    exp := " ORDER BY users.name, users.email"
+    exp := " ORDER BY users.id, users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -135,31 +100,16 @@ func TestOrderByClauseMultiAsc(t *testing.T) {
 func TestOrderByClauseMultiAscDesc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
     ob := &OrderByClause{
         cols: &List{
             elements: []element{
-                &SortColumn{el: cd1},
-                &SortColumn{el: cd2, desc: true},
+                &SortColumn{el: colUserId},
+                &SortColumn{el: colUserName, desc: true},
             },
         },
     }
 
-    exp := " ORDER BY users.name, users.email DESC"
+    exp := " ORDER BY users.id, users.name DESC"
     expLen := len(exp)
     expArgCount := 0
 

--- a/select_test.go
+++ b/select_test.go
@@ -9,19 +9,9 @@ import (
 func TestSelectSingleColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     sel := Select(c)
@@ -36,19 +26,9 @@ func TestSelectSingleColumn(t *testing.T) {
 func TestSelectSingleColumnWithTableAlias(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c := &Column{
-        cdef: cd,
-        tbl: td.As("u"),
+        cdef: colUserName,
+        tbl: users.As("u"),
     }
 
     sel := Select(c)
@@ -63,34 +43,19 @@ func TestSelectSingleColumnWithTableAlias(t *testing.T) {
 func TestSelectMultiColumnsSingleTable(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
     c1 := &Column{
-        cdef: cd1,
-        tbl: td.Table(),
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
+        cdef: colUserId,
+        tbl: users.Table(),
     }
 
     c2 := &Column{
-        cdef: cd2,
-        tbl: td.Table(),
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
     sel := Select(c1, c2)
 
-    exp := "SELECT users.name, users.email FROM users"
+    exp := "SELECT users.id, users.name FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.size())
@@ -100,17 +65,7 @@ func TestSelectMultiColumnsSingleTable(t *testing.T) {
 func TestSelectFromColumnDef(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd)
+    sel := Select(colUserName)
 
     exp := "SELECT users.name FROM users"
     expLen := len(exp)
@@ -122,29 +77,14 @@ func TestSelectFromColumnDef(t *testing.T) {
 func TestSelectFromColumnDefAndColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
+    c := &Column{
+        cdef: colUserName,
+        tbl: users.Table(),
     }
 
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
+    sel := Select(colUserId, c)
 
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
-    c2 := &Column{
-        cdef: cd2,
-        tbl: td.Table(),
-    }
-
-    sel := Select(cd1, c2)
-
-    exp := "SELECT users.name, users.email FROM users"
+    exp := "SELECT users.id, users.name FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.size())
@@ -154,26 +94,9 @@ func TestSelectFromColumnDefAndColumn(t *testing.T) {
 func TestSelectFromTableDef(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
+    sel := Select(users)
 
-    cdefs := []*ColumnDef{
-        &ColumnDef{
-            name: "name",
-            tdef: td,
-        },
-        &ColumnDef{
-            name: "email",
-            tdef: td,
-        },
-    }
-    td.cdefs = cdefs
-
-    sel := Select(td)
-
-    exp := "SELECT users.name, users.email FROM users"
+    exp := "SELECT users.id, users.name FROM users"
     expLen := len(exp)
 
     assert.Equal(expLen, sel.size())
@@ -183,17 +106,7 @@ func TestSelectFromTableDef(t *testing.T) {
 func TestWhereSingleEqual(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).Where(Equal(cd, "foo"))
+    sel := Select(colUserName).Where(Equal(colUserName, "foo"))
 
     exp := "SELECT users.name FROM users WHERE users.name = ?"
     expLen := len(exp)
@@ -207,17 +120,11 @@ func TestWhereSingleEqual(t *testing.T) {
 func TestWhereSingleAnd(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).Where(And(NotEqual(cd, "foo"), NotEqual(cd, "bar")))
+    cond := And(
+        NotEqual(colUserName, "foo"),
+        NotEqual(colUserName, "bar"),
+    )
+    sel := Select(colUserName).Where(cond)
 
     exp := "SELECT users.name FROM users WHERE users.name != ? AND users.name != ?"
     expLen := len(exp)
@@ -231,17 +138,7 @@ func TestWhereSingleAnd(t *testing.T) {
 func TestWhereSingleIn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).Where(In(cd, "foo", "bar"))
+    sel := Select(colUserName).Where(In(colUserName, "foo", "bar"))
 
     exp := "SELECT users.name FROM users WHERE users.name IN (?, ?)"
     expLen := len(exp)
@@ -255,18 +152,8 @@ func TestWhereSingleIn(t *testing.T) {
 func TestWhereMultiNotEqual(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).Where(NotEqual(cd, "foo"))
-    sel = sel.Where(NotEqual(cd, "bar"))
+    sel := Select(colUserName).Where(NotEqual(colUserName, "foo"))
+    sel = sel.Where(NotEqual(colUserName, "bar"))
 
     exp := "SELECT users.name FROM users WHERE users.name != ? AND users.name != ?"
     expLen := len(exp)
@@ -280,22 +167,13 @@ func TestWhereMultiNotEqual(t *testing.T) {
 func TestWhereMultiInAndEqual(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
+    colUserIsAuthor := &ColumnDef{
         name: "is_author",
-        tdef: td,
+        tdef: users,
     }
 
-    sel := Select(cd1).Where(And(In(cd1, "foo", "bar"), Equal(cd2, 1)))
+    cond := And(In(colUserName, "foo", "bar"), Equal(colUserIsAuthor, 1))
+    sel := Select(colUserName).Where(cond)
 
     exp := "SELECT users.name FROM users WHERE users.name IN (?, ?) AND users.is_author = ?"
     expLen := len(exp)
@@ -309,22 +187,7 @@ func TestWhereMultiInAndEqual(t *testing.T) {
 func TestSelectLimit(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
-    }
-
-    sel := Select(c).Limit(10)
+    sel := Select(colUserName).Limit(10)
 
     exp := "SELECT users.name FROM users LIMIT ?"
     expLen := len(exp)
@@ -338,22 +201,7 @@ func TestSelectLimit(t *testing.T) {
 func TestSelectLimitWithOffset(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    c := &Column{
-        cdef: cd,
-        tbl: td.Table(),
-    }
-
-    sel := Select(c).LimitWithOffset(10, 5)
+    sel := Select(colUserName).LimitWithOffset(10, 5)
 
     exp := "SELECT users.name FROM users LIMIT ? OFFSET ?"
     expLen := len(exp)
@@ -367,17 +215,7 @@ func TestSelectLimitWithOffset(t *testing.T) {
 func TestSelectOrderByAsc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).OrderBy(cd.Asc())
+    sel := Select(colUserName).OrderBy(colUserName.Asc())
 
     exp := "SELECT users.name FROM users ORDER BY users.name"
     expLen := len(exp)
@@ -391,24 +229,9 @@ func TestSelectOrderByAsc(t *testing.T) {
 func TestSelectOrderByMultiAscDesc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
+    sel := Select(colUserName).OrderBy(colUserId.Asc(), colUserName.Desc())
 
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
-    sel := Select(cd1).OrderBy(cd1.Asc(), cd2.Desc())
-
-    exp := "SELECT users.name FROM users ORDER BY users.name, users.email DESC"
+    exp := "SELECT users.name FROM users ORDER BY users.id, users.name DESC"
     expLen := len(exp)
     expArgCount := 0
 
@@ -420,17 +243,7 @@ func TestSelectOrderByMultiAscDesc(t *testing.T) {
 func TestSelectStringArgs(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).Where(In(cd, "foo", "bar"))
+    sel := Select(colUserName).Where(In(colUserName, "foo", "bar"))
 
     expStr := "SELECT users.name FROM users WHERE users.name IN (?, ?)"
     expLen := len(expStr)
@@ -449,17 +262,7 @@ func TestSelectStringArgs(t *testing.T) {
 func TestSelectGroupByAsc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).GroupBy(cd)
+    sel := Select(colUserName).GroupBy(colUserName)
 
     exp := "SELECT users.name FROM users GROUP BY users.name"
     expLen := len(exp)
@@ -470,27 +273,12 @@ func TestSelectGroupByAsc(t *testing.T) {
     assert.Equal(exp, sel.String())
 }
 
-func TestSelectGroupByMultiAscDesc(t *testing.T) {
+func TestSelectGroupByMultiAsc(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
+    sel := Select(colUserName).GroupBy(colUserId, colUserName)
 
-    cd1 := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    cd2 := &ColumnDef{
-        name: "email",
-        tdef: td,
-    }
-
-    sel := Select(cd1).GroupBy(cd1, cd2)
-
-    exp := "SELECT users.name FROM users GROUP BY users.name, users.email"
+    exp := "SELECT users.name FROM users GROUP BY users.id, users.name"
     expLen := len(exp)
     expArgCount := 0
 
@@ -502,17 +290,7 @@ func TestSelectGroupByMultiAscDesc(t *testing.T) {
 func TestSelectGroupOrderLimit(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cd := &ColumnDef{
-        name: "name",
-        tdef: td,
-    }
-
-    sel := Select(cd).GroupBy(cd).OrderBy(cd.Desc()).Limit(10)
+    sel := Select(colUserName).GroupBy(colUserName).OrderBy(colUserName.Desc()).Limit(10)
 
     exp := "SELECT users.name FROM users GROUP BY users.name ORDER BY users.name DESC LIMIT ?"
     expLen := len(exp)
@@ -526,30 +304,6 @@ func TestSelectGroupOrderLimit(t *testing.T) {
 func TestSelectJoinSingle(t *testing.T) {
     assert := assert.New(t)
 
-    users := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    colUserId := &ColumnDef{
-        name: "id",
-        tdef: users,
-    }
-
-    users.cdefs = []*ColumnDef{colUserId}
-
-    articles := &TableDef{
-        name: "articles",
-        schema: "test",
-    }
-
-    colArticleAuthor := &ColumnDef{
-        name: "author",
-        tdef: articles,
-    }
-
-    articles.cdefs = []*ColumnDef{colArticleAuthor}
-
     j := &JoinClause{
         left: users,
         right: articles,
@@ -560,7 +314,7 @@ func TestSelectJoinSingle(t *testing.T) {
 
     sel := Select(j)
 
-    exp := "SELECT users.id FROM users JOIN articles ON users.id = articles.author"
+    exp := "SELECT users.id, users.name FROM users JOIN articles ON users.id = articles.author"
     expLen := len(exp)
     expArgCount := 0
 

--- a/table.go
+++ b/table.go
@@ -75,17 +75,17 @@ func (t *Table) As(alias string) *Table {
 }
 
 type TableDef struct {
+    meta *Meta
     name string
-    schema string
     cdefs []*ColumnDef
 }
 
 func (td *TableDef) selectionId() uint64 {
-    return toId(td.schema, td.name)
+    return toId(td.meta.schemaName, td.name)
 }
 
 func (td *TableDef) idParts() []string {
-    return []string{td.schema, td.name}
+    return []string{td.meta.schemaName, td.name}
 }
 
 func (td *TableDef) Table() *Table {

--- a/table_test.go
+++ b/table_test.go
@@ -9,22 +9,13 @@ import (
 func TestTable(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    t1 := &Table{
-        tdef: td,
-    }
-
     exp := "users"
     expLen := len(exp)
-    s := t1.size()
+    s := users.size()
     assert.Equal(expLen, s)
 
     b := make([]byte, s)
-    written, _ := t1.scan(b, nil)
+    written, _ := users.scan(b, nil)
 
     assert.Equal(written, s)
     assert.Equal(exp, string(b))
@@ -33,15 +24,7 @@ func TestTable(t *testing.T) {
 func TestTableAlias(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    t1 := &Table{
-        tdef: td,
-        alias: "u",
-    }
+    t1 := users.As("u")
 
     exp := "users AS u"
     expLen := len(exp)
@@ -60,7 +43,6 @@ func TestTableColumnDefs(t *testing.T) {
 
     td := &TableDef{
         name: "users",
-        schema: "test",
     }
 
     cdefs := []*ColumnDef{
@@ -90,76 +72,29 @@ func TestTableColumnDefs(t *testing.T) {
 func TestTableDefColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
+    c := users.Column("name")
 
-    cdefs := []*ColumnDef{
-        &ColumnDef{
-            name: "id",
-            tdef: td,
-        },
-        &ColumnDef{
-            name: "email",
-            tdef: td,
-        },
-    }
-    td.cdefs = cdefs
-
-    c := td.Column("email")
-
-    assert.Equal(td, c.cdef.tdef)
-    assert.Equal("email", c.cdef.name)
+    assert.Equal(users, c.cdef.tdef)
+    assert.Equal("name", c.cdef.name)
 
     // Check an unknown column name returns nil
-    unknown := td.Column("unknown")
+    unknown := users.Column("unknown")
     assert.Nil(unknown)
 }
 
 func TestTableColumn(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    cdefs := []*ColumnDef{
-        &ColumnDef{
-            name: "id",
-            tdef: td,
-        },
-        &ColumnDef{
-            name: "email",
-            tdef: td,
-        },
-    }
-    td.cdefs = cdefs
-
     tbl := &Table{
-        tdef: td,
+        tdef: users,
     }
 
-    c := tbl.Column("email")
+    c := tbl.Column("name")
 
-    assert.Equal(td, c.cdef.tdef)
-    assert.Equal("email", c.cdef.name)
+    assert.Equal(users, c.cdef.tdef)
+    assert.Equal("name", c.cdef.name)
 
     // Check an unknown column name returns nil
     unknown := tbl.Column("unknown")
     assert.Nil(unknown)
-}
-
-func TestTableAs(t *testing.T) {
-    assert := assert.New(t)
-
-    td := &TableDef{
-        name: "users",
-        schema: "test",
-    }
-
-    t1 := td.As("u")
-    assert.Equal("u", t1.alias)
-    assert.Equal(td, t1.tdef)
 }


### PR DESCRIPTION
Moves the TableDef.schema field to be a pointer to a Meta struct,
reducing the duplicated string information around the schema name.

In the process, dramatically simplify the tests by using a single set of
table and column definition fixtures.