### PR TITLE
Allow for manual metadata construction

### DIFF
--- a/join_test.go
+++ b/join_test.go
@@ -9,7 +9,7 @@ import (
 var (
     meta = &Meta{
         schemaName: "test",
-        tables: make(map[string]*TableDef, 0),
+        tdefs: make(map[string]*TableDef, 0),
     }
 
     users = &TableDef{
@@ -42,8 +42,8 @@ var (
 func init() {
     users.cdefs = []*ColumnDef{colUserId, colUserName}
     articles.cdefs = []*ColumnDef{colArticleId, colArticleAuthor}
-    meta.tables["users"] = users
-    meta.tables["articles"] = articles
+    meta.tdefs["users"] = users
+    meta.tdefs["articles"] = articles
 }
 
 func TestJoinFuncGenerics(t *testing.T) {

--- a/meta.go
+++ b/meta.go
@@ -56,6 +56,14 @@ func (m *Meta) TableDef(tblName string) *TableDef {
     return m.tdefs[tblName]
 }
 
+func (m *Meta) Table(tblName string) *Table {
+    td, found := m.tdefs[tblName]
+    if ! found {
+        return nil
+    }
+    return td.Table()
+}
+
 func Reflect(driver string, db *sql.DB, meta *Meta) error {
     schemaName := getSchemaName(driver, db)
     // Grab information about all tables in the schema

--- a/meta.go
+++ b/meta.go
@@ -31,29 +31,29 @@ ORDER BY c.TABLE_NAME, c.COLUMN_NAME
 type Meta struct {
     db *sql.DB
     schemaName string
-    tables map[string]*TableDef
+    tdefs map[string]*TableDef
 }
 
 func NewMeta(driver string, schemaName string) *Meta {
     return &Meta{
         schemaName: schemaName,
-        tables: make(map[string]*TableDef, 0),
+        tdefs: make(map[string]*TableDef, 0),
     }
 }
 
 // Create and return a new TableDef with the given table name.
-func (m *Meta) NewTable(tblName string) *TableDef {
-    td, exists := m.tables[tblName]
+func (m *Meta) NewTableDef(tblName string) *TableDef {
+    td, exists := m.tdefs[tblName]
     if exists {
         return td
     }
     td = &TableDef{meta: m, name: tblName}
-    m.tables[tblName] = td
+    m.tdefs[tblName] = td
     return td
 }
 
-func (m *Meta) Table(tblName string) *TableDef {
-    return m.tables[tblName]
+func (m *Meta) TableDef(tblName string) *TableDef {
+    return m.tdefs[tblName]
 }
 
 func Reflect(driver string, db *sql.DB, meta *Meta) error {
@@ -76,7 +76,7 @@ func Reflect(driver string, db *sql.DB, meta *Meta) error {
     if err = fillTableColumnDefs(db, schemaName, &tdefs); err != nil {
         return err
     }
-    meta.tables = tdefs
+    meta.tdefs = tdefs
     meta.db = db
     return nil
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -54,17 +54,6 @@ func resetDB(driver string, db *sql.DB) {
     }
 }
 
-func TestNewTable(t *testing.T) {
-    assert := assert.New(t)
-
-    m := NewMeta("mysql", "test")
-    td := m.Table("users")
-    assert.Nil(td)
-    td = m.NewTable("users")
-    assert.NotNil(td)
-    assert.Equal(td.meta, m)
-}
-
 func TestReflectMySQL(t *testing.T) {
     dsn, found := os.LookupEnv("SQLB_TESTING_MYSQL_DSN")
     if ! found {
@@ -81,10 +70,10 @@ func TestReflectMySQL(t *testing.T) {
     err = Reflect("mysql", db, &meta)
     assert.Nil(err)
 
-    assert.Equal(2, len(meta.tables))
+    assert.Equal(2, len(meta.tdefs))
 
-    artTbl := meta.tables["articles"]
-    userTbl := meta.tables["users"]
+    artTbl := meta.tdefs["articles"]
+    userTbl := meta.tdefs["users"]
 
     assert.Equal("articles", artTbl.name)
     assert.Equal("users", userTbl.name)

--- a/table.go
+++ b/table.go
@@ -109,18 +109,28 @@ func (td *TableDef) As(alias string) *Table {
     return &Table{tdef: td, alias: alias}
 }
 
-func (td *TableDef) Column(name string) *Column {
+// Return a pointer to a ColumnDef with a name matching the supplied string, or
+// nil if no such column is known
+func (td *TableDef) ColumnDef(name string) *ColumnDef {
     for _, cdef := range td.cdefs {
         if cdef.name == name {
-            return &Column{
-                cdef: cdef,
-                tbl: &Table{
-                    tdef: td,
-                },
-            }
+            return cdef
         }
     }
     return nil
+}
+
+// Returns a pointer to a Column representing an aliasable version of the table
+// column with the supplied name, or nil if no such column definition is known
+func (td *TableDef) Column(name string) *Column {
+    cd := td.ColumnDef(name)
+    if cd == nil {
+        return nil
+    }
+    return &Column{
+        cdef: cd,
+        tbl: td.Table(),
+    }
 }
 
 func (td *TableDef) projections() []projection {

--- a/table.go
+++ b/table.go
@@ -120,6 +120,19 @@ func (td *TableDef) ColumnDef(name string) *ColumnDef {
     return nil
 }
 
+func (td *TableDef) NewColumnDef(name string) *ColumnDef {
+    cd := td.ColumnDef(name)
+    if cd != nil {
+        return cd
+    }
+    cd = &ColumnDef{
+        name: name,
+        tdef: td,
+    }
+    td.cdefs = append(td.cdefs, cd)
+    return cd
+}
+
 // Returns a pointer to a Column representing an aliasable version of the table
 // column with the supplied name, or nil if no such column definition is known
 func (td *TableDef) Column(name string) *Column {

--- a/table_test.go
+++ b/table_test.go
@@ -6,6 +6,17 @@ import (
     "github.com/stretchr/testify/assert"
 )
 
+func TestTableMeta(t *testing.T) {
+    assert := assert.New(t)
+
+    m := NewMeta("mysql", "test")
+    td := m.TableDef("users")
+    assert.Nil(td)
+    td = m.NewTableDef("users")
+    assert.NotNil(td)
+    assert.Equal(td.meta, m)
+}
+
 func TestTable(t *testing.T) {
     assert := assert.New(t)
 

--- a/table_test.go
+++ b/table_test.go
@@ -15,6 +15,16 @@ func TestTableMeta(t *testing.T) {
     td = m.NewTableDef("users")
     assert.NotNil(td)
     assert.Equal(td.meta, m)
+
+    assert.Equal(td, m.TableDef("users"))
+
+    cd := td.ColumnDef("id")
+    assert.Nil(cd)
+
+    cd = td.NewColumnDef("id")
+    assert.NotNil(cd)
+
+    assert.Equal(cd, td.ColumnDef("id"))
 }
 
 func TestTable(t *testing.T) {


### PR DESCRIPTION
Instead of using the `sqlb.Reflect()` function to automatically query a database/sql:DB instance for table and column information, it's possible to manually construct metadata. However, before this patch, you needed to know sqlb struct internals to do that.

This patch adds some convenience methods to the `sqlb.Meta` and `sqlb.TableDef` structs for manually constructing metadata objects and adds some documentation on how to do so in the form of a library reference document.