### PR TITLE
Dderived table support in sqlb.Select()

### DIFF
--- a/select_clause_test.go
+++ b/select_clause_test.go
@@ -169,15 +169,6 @@ func TestSelectClause(t *testing.T) {
             qs: "SELECT users.name FROM users GROUP BY users.name ORDER BY users.name DESC LIMIT ?",
             qargs: []interface{}{10},
         },
-        // Simple sub-SELECT
-        selClauseTest{
-            c: &selectClause{
-                alias: "u",
-                selections: []selection{users},
-                projs: []projection{colUserName},
-            },
-            qs: "(SELECT users.name FROM users) AS u",
-        },
         // Single join
         selClauseTest{
             c: &selectClause{

--- a/select_test.go
+++ b/select_test.go
@@ -68,6 +68,11 @@ func TestSelectQuery(t *testing.T) {
             q: Select(Select(users).As("u")),
             qs: "SELECT u.id, u.name FROM (SELECT users.id, users.name FROM users) AS u",
         },
+        // Simple un-named derived table
+        selectQueryTest{
+            q: Select(Select(users)),
+            qs: "SELECT derived0.id, derived0.name FROM (SELECT users.id, users.name FROM users) AS derived0",
+        },
         // Simple INNER JOIN
         selectQueryTest{
             q: Select(colArticleId, colUserName.As("author")).Join(users, Equal(colArticleAuthor, colUserId)),

--- a/select_test.go
+++ b/select_test.go
@@ -63,12 +63,10 @@ func TestSelectQuery(t *testing.T) {
             qs: "SELECT users.id, users.name FROM users LIMIT ? OFFSET ?",
             qargs: []interface{}{10, 20},
         },
-        // Simple sub-SELECT
+        // Simple named derived table
         selectQueryTest{
-            q: Select(users).As("u"),
-            // This is incorrect. Should be:
-            // qs: "SELECT u.id, u.name FROM (SELECT users.id, users.name FROM users) AS u",
-            qs: "SELECT users.id, users.name FROM (SELECT users.id, users.name FROM users) AS u",
+            q: Select(Select(users).As("u")),
+            qs: "SELECT u.id, u.name FROM (SELECT users.id, users.name FROM users) AS u",
         },
         // Simple INNER JOIN
         selectQueryTest{


### PR DESCRIPTION
With this patch, we now allow users to create SELECT statements in the FROM clause (derived tables) that are either named (aliased) or unnamed.

For example, we can use the `sqlb.SelectQuery.As()` method to produce a named/aliased SELECT subquery, like so:

```go
subq := sqlb.Select(users).As("u")
```

We can now use that subq struct as an argument to another `sqlb.Select()` call:

```go
q := sqlb.Select(subq)
```

calling `sqlb.SelectQuery.String()` on the above would produce the following SQL:

```sql
SELECT u.id, u.name FROM (
  SELECT users.id, users.name
  FROM users
) AS u
```

If the `sqlb.SelectQuery.As()` method is not used to create a named subselect, the `sqlb.Select()` function will automatically name any subquery with the name template "derived%d", with %d representing a 0-based index of anonymous derived tables.

Issue #10