### PR TITLE
Some cleanups around JOIN handling

### DIFF
--- a/derived.go
+++ b/derived.go
@@ -19,10 +19,6 @@ type derivedTable struct {
     from *selectClause
 }
 
-func (dt *derivedTable) selectionId() uint64 {
-    return toId(dt.alias)
-}
-
 // Return a collection of derivedColumn projections that have been constructed
 // to refer to this derived table and not have any outer alias
 func (dt *derivedTable) getAllDerivedColumns() []projection {

--- a/interfaces.go
+++ b/interfaces.go
@@ -41,7 +41,6 @@ type projection interface {
 // view, subselect, etc.
 type selection interface {
     projections() []projection
-    selectionId() uint64
     // selections must also implement element
     size() int
     argCount() int

--- a/join_test.go
+++ b/join_test.go
@@ -24,11 +24,6 @@ func TestJoinClause(t *testing.T) {
     auCond := Equal(colArticleAuthor, colUserId)
     uaCond := Equal(colUserId, colArticleAuthor)
 
-    join := &joinClause{
-        left: articles.Table(),
-        right: users.Table(),
-        onExprs: []*Expression{},
-    }
     tests := []joinClauseTest{
         // articles to users table defs
         joinClauseTest{
@@ -45,19 +40,12 @@ func TestJoinClause(t *testing.T) {
             c: Join(articles.Table(), users.Table(), auCond),
             qs: " JOIN users ON articles.author = users.id",
         },
-        // joinClause.On() method
-        joinClauseTest{
-            c: join.On(auCond),
-            qs: " JOIN users ON articles.author = users.id",
-        },
         // join an aliased table to non-aliased table
         joinClauseTest{
             c: &joinClause{
                 left: articles.As("a"),
                 right: users.Table(),
-                onExprs: []*Expression{
-                    Equal(articles.As("a").Column("author"), colUserId),
-                },
+                on: Equal(articles.As("a").Column("author"), colUserId),
             },
             qs: " JOIN users ON a.author = users.id",
         },
@@ -66,9 +54,7 @@ func TestJoinClause(t *testing.T) {
             c: &joinClause{
                 left: articles,
                 right: users.As("u"),
-                onExprs: []*Expression{
-                    Equal(colArticleAuthor, users.As("u").Column("id")),
-                },
+                on: Equal(colArticleAuthor, users.As("u").Column("id")),
             },
             qs: " JOIN users AS u ON articles.author = u.id",
         },
@@ -77,9 +63,7 @@ func TestJoinClause(t *testing.T) {
             c: &joinClause{
                 left: articles,
                 right: users,
-                onExprs: []*Expression{
-                    Equal(colArticleAuthor, colUserId.As("user_id")),
-                },
+                on: Equal(colArticleAuthor, colUserId.As("user_id")),
             },
             qs: " JOIN users ON articles.author = users.id",
         },
@@ -89,9 +73,7 @@ func TestJoinClause(t *testing.T) {
                 joinType: JOIN_OUTER,
                 left: articles,
                 right: users,
-                onExprs: []*Expression{
-                    Equal(colArticleAuthor, colUserId),
-                },
+                on: Equal(colArticleAuthor, colUserId),
             },
             qs: " LEFT JOIN users ON articles.author = users.id",
         },

--- a/select.go
+++ b/select.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-    ERR_JOIN_INVALID = errors.New("Unable to join selection. Either there was no selection to join to or the target selection was not found.")
+    ERR_JOIN_INVALID_NO_SELECT = errors.New("Unable to join selection. There was no selection to join to.")
+    ERR_JOIN_INVALID_UNKNOWN_TARGET = errors.New("Unable to join selection. Target selection was not found.")
 )
 
 type SelectQuery struct {
@@ -94,9 +95,8 @@ func (q *SelectQuery) As(alias string) *SelectQuery {
 // not reference any selection that is found in the SelectQuery's selectClause, then
 // SelectQuery.e will be set to an error.
 func (q *SelectQuery) Join(right selection, on *Expression) *SelectQuery {
-    if q.sel == nil {
-        q.e = ERR_JOIN_INVALID
-        fmt.Println("No select clause.")
+    if q.sel == nil || len(q.sel.selections) == 0 {
+        q.e = ERR_JOIN_INVALID_NO_SELECT
         return q
     }
 
@@ -125,7 +125,7 @@ func (q *SelectQuery) Join(right selection, on *Expression) *SelectQuery {
         }
     }
     if left == nil {
-        q.e = ERR_JOIN_INVALID
+        q.e = ERR_JOIN_INVALID_UNKNOWN_TARGET
         return q
     }
     jc := Join(left, right, on)

--- a/select.go
+++ b/select.go
@@ -93,7 +93,7 @@ func (q *SelectQuery) As(alias string) *SelectQuery {
 // does not yet contain a selectClause OR if the supplied ON expression does
 // not reference any selection that is found in the SelectQuery's selectClause, then
 // SelectQuery.e will be set to an error.
-func (q *SelectQuery) Join(right selection, onExpr *Expression) *SelectQuery {
+func (q *SelectQuery) Join(right selection, on *Expression) *SelectQuery {
     if q.sel == nil {
         q.e = ERR_JOIN_INVALID
         fmt.Println("No select clause.")
@@ -103,19 +103,18 @@ func (q *SelectQuery) Join(right selection, onExpr *Expression) *SelectQuery {
     // Let's first determine which selection is targeted as the LEFT part of
     // the join.
     var left selection
-    rightSelId := right.selectionId()
-    for _, el := range onExpr.elements {
+    for _, el := range on.elements {
         switch el.(type) {
             case projection:
                 p := el.(projection)
-                exprSelId := p.from().selectionId()
-                if exprSelId == rightSelId {
+                exprSel := p.from()
+                if exprSel == right {
                     continue
                 }
                 // Search through the SelectQuery's primary selectClause, looking for
                 // the selection that is referred to be the ON expression.
                 for _, sel := range q.sel.selections {
-                    if sel.selectionId() == exprSelId {
+                    if sel == exprSel {
                         left = sel
                         break
                     }
@@ -129,7 +128,7 @@ func (q *SelectQuery) Join(right selection, onExpr *Expression) *SelectQuery {
         q.e = ERR_JOIN_INVALID
         return q
     }
-    jc := Join(left, right, onExpr)
+    jc := Join(left, right, on)
     q.sel.addJoin(jc)
 
     // Make sure we remove the right-hand selection from the selectClause's
@@ -144,7 +143,7 @@ func Select(items ...interface{}) *SelectQuery {
     }
 
     nDerived := 0
-    selectionMap := make(map[uint64]selection, 0)
+    selectionMap := make(map[selection]bool, 0)
     projectionMap := make(map[uint64]projection, 0)
 
     // For each scannable item we've received in the call, check what concrete
@@ -159,9 +158,8 @@ func Select(items ...interface{}) *SelectQuery {
                 sq := item.(*SelectQuery)
                 innerSelClause := sq.sel
                 if len(innerSelClause.selections) == 1 {
-                    innerSelection := innerSelClause.selections[0]
-                    innerSelId := innerSelection.selectionId()
-                    switch innerSelection.(type) {
+                    innerSel := innerSelClause.selections[0]
+                    switch innerSel.(type) {
                         case *derivedTable:
                             // If the inner select clause contains a single
                             // selection and that selection is a derivedTable,
@@ -175,8 +173,8 @@ func Select(items ...interface{}) *SelectQuery {
                             // for the outer selectClause and project all the
                             // derived table's projections out into the outer
                             // selectClause.
-                            selectionMap[innerSelId] = innerSelection
-                            dt := innerSelection.(*derivedTable)
+                            selectionMap[innerSel] = true
+                            dt := innerSel.(*derivedTable)
                             for _, p := range dt.getAllDerivedColumns() {
                                 pid := p.projectionId()
                                 projectionMap[pid] = p
@@ -194,7 +192,7 @@ func Select(items ...interface{}) *SelectQuery {
                                 alias: derivedName,
                                 from: innerSelClause,
                             }
-                            selectionMap[innerSelId] = dt
+                            selectionMap[dt] = true
                             for _, p := range dt.getAllDerivedColumns() {
                                 pid := p.projectionId()
                                 projectionMap[pid] = p
@@ -207,8 +205,8 @@ func Select(items ...interface{}) *SelectQuery {
                 j := item.(*joinClause)
                 if ! containsJoin(sel, j) {
                     sel.joins = append(sel.joins, j)
-                    if _, ok := selectionMap[j.left.selectionId()]; ! ok {
-                        selectionMap[j.left.selectionId()] = j.left
+                    if _, ok := selectionMap[j.left]; ! ok {
+                        selectionMap[j.left] = true
                         for _, proj := range j.left.projections() {
                             projId := proj.projectionId()
                             _, projExists := projectionMap[projId]
@@ -218,7 +216,7 @@ func Select(items ...interface{}) *SelectQuery {
                             }
                         }
                     }
-                    if _, ok := selectionMap[j.right.selectionId()]; ! ok {
+                    if _, ok := selectionMap[j.right]; ! ok {
                         for _, proj := range j.right.projections() {
                             projId := proj.projectionId()
                             _, projExists := projectionMap[projId]
@@ -232,23 +230,23 @@ func Select(items ...interface{}) *SelectQuery {
             case *Column:
                 v := item.(*Column)
                 sel.projs = append(sel.projs, v)
-                selectionMap[v.tbl.selectionId()] = v.tbl
+                selectionMap[v.tbl] = true
             case *Table:
                 v := item.(*Table)
                 for _, cd := range v.tdef.projections() {
                     addToProjections(sel, cd)
                 }
-                selectionMap[v.selectionId()] = v
+                selectionMap[v] = true
             case *TableDef:
                 v := item.(*TableDef)
                 for _, cd := range v.projections() {
                     addToProjections(sel, cd)
                 }
-                selectionMap[v.selectionId()] = v
+                selectionMap[v] = true
             case *ColumnDef:
                 v := item.(*ColumnDef)
                 addToProjections(sel, v)
-                selectionMap[v.tdef.selectionId()] = v.tdef
+                selectionMap[v.tdef] = true
             default:
                 // Everything else, make it a literal value projection, so, for
                 // instance, a user can do SELECT 1, which is, technically
@@ -259,7 +257,7 @@ func Select(items ...interface{}) *SelectQuery {
     }
     selections := make([]selection, len(selectionMap))
     x := 0
-    for _, sel := range selectionMap {
+    for sel, _ := range selectionMap {
         selections[x] = sel
         x++
     }

--- a/select_clause.go
+++ b/select_clause.go
@@ -208,9 +208,8 @@ func addToProjections(s *selectClause, p projection) {
 
 func (s *selectClause) removeSelection(toRemove selection) {
     idx := -1
-    toRemoveId := toRemove.selectionId()
     for x, sel := range s.selections {
-        if sel.selectionId() == toRemoveId {
+        if sel == toRemove {
             idx = x
             break
         }

--- a/select_clause_test.go
+++ b/select_clause_test.go
@@ -178,9 +178,7 @@ func TestSelectClause(t *testing.T) {
                     &joinClause{
                         left: articles,
                         right: users,
-                        onExprs: []*Expression{
-                            Equal(colArticleAuthor, colUserId),
-                        },
+                        on: Equal(colArticleAuthor, colUserId),
                     },
                 },
             },
@@ -195,16 +193,12 @@ func TestSelectClause(t *testing.T) {
                     &joinClause{
                         left: articles,
                         right: users,
-                        onExprs: []*Expression{
-                            Equal(colArticleAuthor, colUserId),
-                        },
+                        on: Equal(colArticleAuthor, colUserId),
                     },
                     &joinClause{
                         left: articles,
                         right: article_states,
-                        onExprs: []*Expression{
-                            Equal(colArticleState, colArticleStateId),
-                        },
+                        on: Equal(colArticleState, colArticleStateId),
                     },
                 },
             },

--- a/select_test.go
+++ b/select_test.go
@@ -19,15 +19,15 @@ func TestSelectQuery(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    articles := m.TableDef("articles")
-    article_states := m.TableDef("article_states")
+    articles := m.Table("articles")
+    article_states := m.Table("article_states")
     colUserId := users.Column("id")
     colUserName := users.Column("name")
     colArticleId := articles.Column("id")
     colArticleAuthor := articles.Column("author")
-    colArticleState := articles.ColumnDef("state")
-    colArticleStateId := article_states.ColumnDef("id")
-    colArticleStateName := article_states.ColumnDef("name")
+    colArticleState := articles.Column("state")
+    colArticleStateId := article_states.Column("id")
+    colArticleStateName := article_states.Column("name")
 
     tests := []selectQueryTest{
         // Simple FROM

--- a/table.go
+++ b/table.go
@@ -5,13 +5,6 @@ type Table struct {
     tdef *TableDef
 }
 
-func (t *Table) selectionId() uint64 {
-    if t.alias != "" {
-        return toId(t.alias)
-    }
-    return t.tdef.selectionId()
-}
-
 func (t *Table) idParts() []string {
     if t.alias != "" {
         return []string{t.alias}
@@ -78,10 +71,6 @@ type TableDef struct {
     meta *Meta
     name string
     cdefs []*ColumnDef
-}
-
-func (td *TableDef) selectionId() uint64 {
-    return toId(td.meta.schemaName, td.name)
 }
 
 func (td *TableDef) idParts() []string {


### PR DESCRIPTION
* Differentiate errors from attempting to join to an empty selectClause versus attempting to join to an unknown selection
* Remove the array of *Expression struct pointers in the joinClause struct since we support composite Expressions like And() and Or()
* Remove the selectionId() method of the selection interface