### PR TITLE
Implement IS NULL and IS NOT NULL

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -10,6 +10,7 @@ const (
     EXP_IN
     EXP_BETWEEN
     EXP_IS_NULL
+    EXP_IS_NOT_NULL
 )
 
 var (
@@ -36,6 +37,9 @@ var (
         },
         EXP_IS_NULL: scanInfo{
             SYM_ELEMENT, SYM_IS_NULL,
+        },
+        EXP_IS_NOT_NULL: scanInfo{
+            SYM_ELEMENT, SYM_IS_NOT_NULL,
         },
     }
 )
@@ -161,6 +165,13 @@ func Between(subject element, start interface{}, end interface{}) *Expression {
 func IsNull(subject element) *Expression {
     return &Expression{
         scanInfo: exprScanTable[EXP_IS_NULL],
+        elements: []element{subject},
+    }
+}
+
+func IsNotNull(subject element) *Expression {
+    return &Expression{
+        scanInfo: exprScanTable[EXP_IS_NOT_NULL],
         elements: []element{subject},
     }
 }

--- a/expression.go
+++ b/expression.go
@@ -11,35 +11,33 @@ const (
     EXP_BETWEEN
 )
 
-type exprScanInfo []Symbol
-
 var (
     // A static table containing information used in constructing the
     // expression's SQL string during scan() calls
-    exprScanTable = map[exprType]exprScanInfo{
-        EXP_EQUAL: exprScanInfo{
+    exprScanTable = map[exprType]scanInfo{
+        EXP_EQUAL: scanInfo{
             SYM_ELEMENT, SYM_EQUAL, SYM_ELEMENT,
         },
-        EXP_NEQUAL: exprScanInfo{
+        EXP_NEQUAL: scanInfo{
             SYM_ELEMENT, SYM_NEQUAL, SYM_ELEMENT,
         },
-        EXP_AND: exprScanInfo{
+        EXP_AND: scanInfo{
             SYM_LPAREN, SYM_ELEMENT, SYM_AND, SYM_ELEMENT, SYM_RPAREN,
         },
-        EXP_OR: exprScanInfo{
+        EXP_OR: scanInfo{
             SYM_LPAREN, SYM_ELEMENT, SYM_OR, SYM_ELEMENT, SYM_RPAREN,
         },
-        EXP_IN: exprScanInfo{
+        EXP_IN: scanInfo{
             SYM_ELEMENT, SYM_IN, SYM_ELEMENT, SYM_RPAREN,
         },
-        EXP_BETWEEN: exprScanInfo{
+        EXP_BETWEEN: scanInfo{
             SYM_ELEMENT, SYM_BETWEEN, SYM_ELEMENT, SYM_AND, SYM_ELEMENT,
         },
     }
 )
 
 type Expression struct {
-    scanInfo exprScanInfo
+    scanInfo scanInfo
     elements []element
 }
 

--- a/expression.go
+++ b/expression.go
@@ -9,6 +9,7 @@ const (
     EXP_OR
     EXP_IN
     EXP_BETWEEN
+    EXP_IS_NULL
 )
 
 var (
@@ -32,6 +33,9 @@ var (
         },
         EXP_BETWEEN: scanInfo{
             SYM_ELEMENT, SYM_BETWEEN, SYM_ELEMENT, SYM_AND, SYM_ELEMENT,
+        },
+        EXP_IS_NULL: scanInfo{
+            SYM_ELEMENT, SYM_IS_NULL,
         },
     }
 )
@@ -151,5 +155,12 @@ func Between(subject element, start interface{}, end interface{}) *Expression {
     return &Expression{
         scanInfo: exprScanTable[EXP_BETWEEN],
         elements: els,
+    }
+}
+
+func IsNull(subject element) *Expression {
+    return &Expression{
+        scanInfo: exprScanTable[EXP_IS_NULL],
+        elements: []element{subject},
     }
 }

--- a/expression_test.go
+++ b/expression_test.go
@@ -87,6 +87,11 @@ func TestExpressions(t *testing.T) {
             c: IsNull(colUserName),
             qs: "users.name IS NULL",
         },
+        // column IS NOT NULL
+        expressionTest{
+            c: IsNotNull(colUserName),
+            qs: "users.name IS NOT NULL",
+        },
     }
     for _, test := range tests {
         expLen := len(test.qs)

--- a/expression_test.go
+++ b/expression_test.go
@@ -82,6 +82,11 @@ func TestExpressions(t *testing.T) {
             qs: "users.name BETWEEN ? AND ?",
             qargs: []interface{}{"foo", "bar"},
         },
+        // column IS NULL
+        expressionTest{
+            c: IsNull(colUserName),
+            qs: "users.name IS NULL",
+        },
     }
     for _, test := range tests {
         expLen := len(test.qs)

--- a/symbol.go
+++ b/symbol.go
@@ -29,6 +29,7 @@ const (
     SYM_EQUAL
     SYM_NEQUAL
     SYM_BETWEEN
+    SYM_IS_NULL
     SYM_MAX
     SYM_MIN
     SYM_SUM
@@ -81,6 +82,7 @@ var (
         SYM_EQUAL: []byte(" = "),
         SYM_NEQUAL: []byte(" != "),
         SYM_BETWEEN: []byte(" BETWEEN "),
+        SYM_IS_NULL: []byte(" IS NULL"),
         SYM_MAX: []byte("MAX("),
         SYM_MIN: []byte("MIN("),
         SYM_SUM: []byte("SUM("),

--- a/symbol.go
+++ b/symbol.go
@@ -30,6 +30,7 @@ const (
     SYM_NEQUAL
     SYM_BETWEEN
     SYM_IS_NULL
+    SYM_IS_NOT_NULL
     SYM_MAX
     SYM_MIN
     SYM_SUM
@@ -83,6 +84,7 @@ var (
         SYM_NEQUAL: []byte(" != "),
         SYM_BETWEEN: []byte(" BETWEEN "),
         SYM_IS_NULL: []byte(" IS NULL"),
+        SYM_IS_NOT_NULL: []byte(" IS NOT NULL"),
         SYM_MAX: []byte("MAX("),
         SYM_MIN: []byte("MIN("),
         SYM_SUM: []byte("SUM("),


### PR DESCRIPTION
Adds `sqlb.IsNull()` and `sqlb.IsNotNull()` functions that produce expressions outputting the SQL string for "element IS [NOT] NULL".

Closes Issue #55 