### PR TITLE
Search joinClause structs for matching LEFT join

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -89,12 +89,31 @@ func testFixtureMeta() *Meta {
         tdef: article_states,
     }
 
+    user_profiles := &TableDef{
+        meta: meta,
+        name: "user_profiles",
+    }
+    colUserProfileId := &ColumnDef{
+        name: "id",
+        tdef: user_profiles,
+    }
+    colUserProfileContent := &ColumnDef{
+        name: "content",
+        tdef: user_profiles,
+    }
+    colUserProfileUser := &ColumnDef{
+        name: "user",
+        tdef: user_profiles,
+    }
+
     users.cdefs = []*ColumnDef{colUserId, colUserName}
     articles.cdefs = []*ColumnDef{colArticleId, colArticleAuthor, colArticleState}
     article_states.cdefs = []*ColumnDef{colArticleStateId, colArticleStateName}
+    user_profiles.cdefs = []*ColumnDef{colUserProfileId, colUserProfileUser, colUserProfileContent}
     meta.tdefs["users"] = users
     meta.tdefs["articles"] = articles
     meta.tdefs["article_states"] = article_states
+    meta.tdefs["user_profiles"] = user_profiles
     return meta
 }
 

--- a/select.go
+++ b/select.go
@@ -185,6 +185,18 @@ func (q *SelectQuery) doJoin(
                 if left != nil {
                     break
                 }
+                // Now search through the SelectQuery's joinClauses, looking
+                // for a selection that is the left side of the ON expression
+                for _, j := range q.sel.joins {
+                    if j.left == exprSel {
+                        left = j.left
+                    } else if j.right == exprSel {
+                        left = j.right
+                    }
+                }
+                if left != nil {
+                    break
+                }
             case *Expression:
                 expr := el.(*Expression)
                 for _, referrent := range expr.referrents() {
@@ -195,6 +207,18 @@ func (q *SelectQuery) doJoin(
                         if sel == referrent {
                             left = sel
                             break
+                        }
+                    }
+                    if left != nil {
+                        break
+                    }
+                    // Now search through the SelectQuery's joinClauses, looking
+                    // for a selection that is the left side of the ON expression
+                    for _, j := range q.sel.joins {
+                        if j.left == referrent {
+                            left = j.left
+                        } else if j.right == referrent {
+                            left = j.right
                         }
                     }
                     if left != nil {


### PR DESCRIPTION
When looking for the selection that comprises the LEFT part of a
Join()'d selection, we were searching through the projections in the ON
expression and looking to see if any of the selections of the primary
selectClause struct matched the non-right part of the JOIN expression.
This worked fine for joins of the type A to B and A to C, for example
if we were doing something like this:

```sql
SELECT
  articles.id, users.name AS author, article_states.name AS state
FROM articles
JOIN users
  ON articles.author = users.id
JOIN article_states
  ON articles.state = article_states.id
```

However, if we attempted to do a join of the type A to B and B to C,
for example:

```sql
SELECT
  articles.id, users.name AS author, user_profiles.content AS author_profile
FROM articles
JOIN users
  ON articles.author = users.id
JOIN user_profiles
  ON users.id = user_profiles.user
```

Then we were failing to properly identify the users selection as the
LEFT part of the second join. This patch fixes that by searching
through the primary SelectQuery's selectClause's joins collection to
identify the appropriate LEFT side of the join.

Closes Issue #60