### PR TITLE
Overhaul column/table structs and fix argCount()

### DIFF
--- a/column.go
+++ b/column.go
@@ -2,7 +2,7 @@ package sqlb
 
 type Column struct {
     alias string
-    cdef *ColumnDef
+    name string
     tbl *Table
 }
 
@@ -29,10 +29,10 @@ func (c *Column) size() int {
     if c.tbl.alias != "" {
         size += len(c.tbl.alias)
     } else {
-        size += len(c.tbl.tdef.name)
+        size += len(c.tbl.name)
     }
     size += len(Symbols[SYM_PERIOD])
-    size += len(c.cdef.name)
+    size += len(c.name)
     if c.alias != "" {
         size += len(Symbols[SYM_AS]) + len(c.alias)
     }
@@ -44,10 +44,10 @@ func (c *Column) scan(b []byte, args []interface{}) (int, int) {
     if c.tbl.alias != "" {
         bw += copy(b[bw:], c.tbl.alias)
     } else {
-        bw += copy(b[bw:], c.tbl.tdef.name)
+        bw += copy(b[bw:], c.tbl.name)
     }
     bw += copy(b[bw:], Symbols[SYM_PERIOD])
-    bw += copy(b[bw:], c.cdef.name)
+    bw += copy(b[bw:], c.name)
     if c.alias != "" {
         bw += copy(b[bw:], Symbols[SYM_AS])
         bw += copy(b[bw:], c.alias)
@@ -62,56 +62,7 @@ func (c *Column) setAlias(alias string) {
 func (c *Column) As(alias string) *Column {
     return &Column{
         alias: alias,
+        name: c.name,
         tbl: c.tbl,
-        cdef: c.cdef,
-    }
-}
-
-type ColumnDef struct {
-    name string
-    tdef *TableDef
-}
-
-func (cd *ColumnDef) from() selection {
-    return cd.tdef
-}
-
-// A column definition isn't aliasable...
-func (cd *ColumnDef) disableAliasScan() func() {
-    return func() {}
-}
-
-func (cd *ColumnDef) Column() *Column {
-    return &Column{
-        cdef: cd,
-        tbl: &Table{
-            tdef: cd.tdef,
-        },
-    }
-}
-
-func (cd *ColumnDef) argCount() int {
-    return 0
-}
-
-func (cd *ColumnDef) size() int {
-    return len(cd.tdef.name) + len(Symbols[SYM_PERIOD]) + len(cd.name)
-}
-
-func (cd *ColumnDef) scan(b []byte, args []interface{}) (int, int) {
-    bw := copy(b, cd.tdef.name)
-    bw += copy(b[bw:], Symbols[SYM_PERIOD])
-    bw += copy(b[bw:], cd.name)
-    return bw, 0
-}
-
-// Generate an aliased Column from a ColumnDef
-func (cd *ColumnDef) As(alias string) *Column {
-    return &Column{
-        cdef: cd,
-        alias: alias,
-        tbl: &Table{
-            tdef: cd.tdef,
-        },
     }
 }

--- a/column.go
+++ b/column.go
@@ -10,16 +10,6 @@ func (c *Column) from() selection {
     return c.tbl
 }
 
-func (c *Column) projectionId() uint64 {
-    if c.alias != "" {
-        args := c.tbl.idParts()
-        args = append(args, c.alias)
-        return toId(args...)
-    }
-    args := c.cdef.idParts()
-    return toId(args...)
-}
-
 func (c *Column) disableAliasScan() func() {
     origAlias := c.alias
     c.alias = ""
@@ -89,16 +79,6 @@ func (cd *ColumnDef) from() selection {
 // A column definition isn't aliasable...
 func (cd *ColumnDef) disableAliasScan() func() {
     return func() {}
-}
-
-func (cd *ColumnDef) projectionId() uint64 {
-    args := cd.tdef.idParts()
-    args = append(args, cd.name)
-    return toId(args...)
-}
-
-func (cd *ColumnDef) idParts() []string {
-    return []string{cd.name, cd.tdef.meta.schemaName, cd.tdef.name}
 }
 
 func (cd *ColumnDef) Column() *Column {

--- a/derived.go
+++ b/derived.go
@@ -29,8 +29,6 @@ func (dt *derivedTable) getAllDerivedColumns() []projection {
         switch p.(type) {
             case *Column:
                 projs[x] = &derivedColumn{dt: dt, c: p.(*Column)}
-            case *ColumnDef:
-                projs[x] = &derivedColumn{dt: dt, c: p.(*ColumnDef).Column()}
         }
     }
     return projs
@@ -43,14 +41,13 @@ func (dt *derivedTable) projections() []projection {
         p := dt.from.projs[x]
         switch p.(type) {
             case *Column:
-            case *ColumnDef:
         }
     }
     return projs
 }
 
 func (dt *derivedTable) argCount() int {
-    return 0
+    return dt.from.argCount()
 }
 
 func (dt *derivedTable) size() int {
@@ -139,7 +136,7 @@ func (dc *derivedColumn) projectionId() uint64 {
     } else if dc.c.alias != "" {
         args[1] = dc.c.alias
     } else {
-        args[1] = dc.c.cdef.name
+        args[1] = dc.c.name
     }
     return toId(args...)
 }
@@ -160,7 +157,7 @@ func (dc *derivedColumn) size() int {
     if dc.c.alias != "" {
         size += len(dc.c.alias)
     } else {
-        size += len(dc.c.cdef.name)
+        size += len(dc.c.name)
     }
     if dc.alias != "" {
         size += len(Symbols[SYM_AS]) + len(dc.alias)
@@ -175,7 +172,7 @@ func (dc *derivedColumn) scan(b []byte, args []interface{}) (int, int) {
     if dc.c.alias != "" {
         bw += copy(b[bw:], dc.c.alias)
     } else {
-        bw += copy(b[bw:], dc.c.cdef.name)
+        bw += copy(b[bw:], dc.c.name)
     }
     if dc.alias != "" {
         bw += copy(b[bw:], Symbols[SYM_AS])

--- a/derived_test.go
+++ b/derived_test.go
@@ -16,8 +16,8 @@ func TestDerived(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
-    colUserName := users.ColumnDef("name")
+    users := m.Table("users")
+    colUserName := users.Column("name")
 
     tests := []derivedTest{
         // Simple one-column sub-SELECT

--- a/docs/how-to/derived-tables.md
+++ b/docs/how-to/derived-tables.md
@@ -77,16 +77,16 @@ simple. The `sqlb.SelectQuery` struct that is returned from the `sqlb.Select()`
 function can be joined to another `sqlb.SelectQuery`, as this example shows:
 
 ```go
-u := meta.TableDef("users")
-a := meta.TableDef("articles")
-c := meta.TableDef("comments")
+u := meta.Table("users")
+a := meta.Table("articles")
+c := meta.Table("comments")
 
-usersId := u.ColumnDef("id")
-articlesId := a.ColumnDef("id")
-articlesAuthor := a.ColumnDef("author")
-articlesIsAuthor := a.ColumnDef("is_author")
-commentsArticleId := c.ColumnDef("article_id")
-commentsCreatedOn := c.ColumnDef("created_on")
+usersId := u.Column("id")
+articlesId := a.Column("id")
+articlesAuthor := a.Column("author")
+articlesIsAuthor := a.Column("is_author")
+commentsArticleId := c.Column("article_id")
+commentsCreatedOn := c.Column("created_on")
 
 // First, build the subquery in the FROM clause (the derived table)
 subq := sqlb.Select(usersId).Join(a, sqlb.Equal(usersId, articlesAuthor))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,42 +67,42 @@ func main() {
 }
 ```
 
-The `sqlb.Meta` struct has a method `TableDef(string)` which returns a pointer
-to a `sqlb.TableDef` struct for a table whose name matches the supplied string
+The `sqlb.Meta` struct has a method `Table(string)` which returns a pointer
+to a `sqlb.Table` struct for a table whose name matches the supplied string
 argument. If no matching table is found, `nil` is returned:
 
 ```go
-    users := meta.TableDef("users")
+    users := meta.Table("users")
     // users == nil
 ```
 
 Since we have yet not told the `meta` struct about any tables in our database,
 the `users` variable above will be `nil`. Let's now tell the `meta` struct
-about the tables in our schema. A `sqlb.TableDef` struct contains metadata
+about the tables in our schema. A `sqlb.Table` struct contains metadata
 about a specific table in a database. The `sqlb.Meta.NewTable()` method
-returns a pointer to a `sqlb.TableDef` struct that's been initialized with the
+returns a pointer to a `sqlb.Table` struct that's been initialized with the
 name of the table.
 
 ```go
-    users = meta.NewTableDef("users")
+    users = meta.NewTable("users")
 ```
 
 A similar process is used to set metadata about a table's column definitions.
-The `sqlb.ColumnDef` struct defines the column name and links a pointer to
-the appropriate `TableDef` struct. To look up a particular column by its name,
-use the `sqlb.TableDef.ColumnDef()` method. If no such column is known, `nil`
+The `sqlb.Column` struct defines the column name and links a pointer to
+the appropriate `Table` struct. To look up a particular column by its name,
+use the `sqlb.Table.Column()` method. If no such column is known, `nil`
 will be returned:
 
 ```go
-    colUserId := users.ColumnDef("id")
+    colUserId := users.Column("id")
     // colUserId == nil
 ```
 
-Use the `sqlb.TableDef.NewColumnDef()` method to create and return a new column
+Use the `sqlb.Table.NewColumn()` method to create and return a new column
 definition:
 
 ```go
-    colUserId = users.NewColumnDef("id")
+    colUserId = users.NewColumn("id")
 ```
 
 ### Automatically discovering metadata
@@ -144,9 +144,9 @@ func main() {
     // meta variable is now populate with table and column information for the
     // "blog" database. Here's some example code that loops through the table
     // metadata printing out table and column names.
-    for _, td := range meta.TableDefs() {
+    for _, td := range meta.Tables() {
         fmt.Printf("Table: %s\n", td.name)
-        for _, cd := range td.ColumnDefs() {
+        for _, cd := range td.Columns() {
             fmt.Printf(" Column: %s", cd.name)
         }
     }
@@ -200,26 +200,26 @@ That said, there's a more convenient way to get a pointer to an aliased
 database object: using the `As()` method on another struct.
 
 As you learned earlier, the `sqlb.Meta` struct contains definitions of tables
-in a database. A `sqlb` user can grab a pointer to one of these `sqlb.TableDef`
-structs by calling the `sqlb.Meta.TableDef()` method, passing in a string for
+in a database. A `sqlb` user can grab a pointer to one of these `sqlb.Table`
+structs by calling the `sqlb.Meta.Table()` method, passing in a string for
 the table name to get a definition for:
 
 ```go
-    orgsTableDef := meta.TableDef("organizations")
+    orgsTable := meta.Table("organizations")
 ```
 
-Use the `sqlb.TableDef.As()` method to get a pointer to a `sqlb.Table` struct
+Use the `sqlb.Table.As()` method to get a pointer to a `sqlb.Table` struct
 that has had its alias set:
 
 ```go
-    orgs := orgsTableDef.As("o")
+    orgs := orgsTable.As("o")
 ```
 
 If you're sure that a particular table exists in the `sqlb.Meta`, you can
 shorten all of the above to just one line:
 
 ```go
-    orgs := meta.TableDef("organizations").As("o")
+    orgs := meta.Table("organizations").As("o")
 ```
 
 Short and sweet.
@@ -283,7 +283,7 @@ SELECT COUNT(DISTINCT author) FROM articles
 
 The `sqlb.Sum()`, `sqlb.Avg()`, `sqlb.`Min()`, and `sqlb.Max()` functions
 produce the associated SQL aggregate functions. They all take a single argument
-which cam be a `Column`, `ColumnDef` or the result of another SQL function,
+which cam be a `Column`, `Column` or the result of another SQL function,
 as these examples show:
 
 
@@ -301,15 +301,15 @@ SELECT MIN(created_on) AS earliest_article FROM articles
 
 Here's an example that involves a `JOIN` between an `orders` and
 `order\_details` table using the `sqlb.Sum()` call to produce an aliased
-projection of `SUM(od.amount) AS total`_amount` in the resulting SQL string.
+projection of `SUM(od.amount) AS `total\_amount` in the resulting SQL string.
 
 ```go
-    o := meta.TableDef("orders").As("o")
-    od := meta.TableDef("order_details").As("od")
-    oId := o.ColumnDef("id")
-    oCustomer := o.ColumnDef("customer")
-    odOrderId := od.ColumnDef("order_id")
-    odAmount := od.ColumnDef("amount")
+    o := meta.Table("orders").As("o")
+    od := meta.Table("order_details").As("od")
+    oId := o.Column("id")
+    oCustomer := o.Column("customer")
+    odOrderId := od.Column("order_id")
+    odAmount := od.Column("amount")
 
     q := sqlb.Select(
         oCustomer,

--- a/function.go
+++ b/function.go
@@ -170,10 +170,6 @@ func (c *Column) Max() *sqlFunc {
     return Max(c)
 }
 
-func (c *ColumnDef) Max() *sqlFunc {
-    return Max(c)
-}
-
 func Min(p projection) *sqlFunc {
     return &sqlFunc{
         scanInfo: funcScanTable[FUNC_MIN],
@@ -183,10 +179,6 @@ func Min(p projection) *sqlFunc {
 }
 
 func (c *Column) Min() *sqlFunc {
-    return Min(c)
-}
-
-func (c *ColumnDef) Min() *sqlFunc {
     return Min(c)
 }
 
@@ -202,10 +194,6 @@ func (c *Column) Sum() *sqlFunc {
     return Sum(c)
 }
 
-func (c *ColumnDef) Sum() *sqlFunc {
-    return Sum(c)
-}
-
 func Avg(p projection) *sqlFunc {
     return &sqlFunc{
         scanInfo: funcScanTable[FUNC_AVG],
@@ -215,10 +203,6 @@ func Avg(p projection) *sqlFunc {
 }
 
 func (c *Column) Avg() *sqlFunc {
-    return Avg(c)
-}
-
-func (c *ColumnDef) Avg() *sqlFunc {
     return Avg(c)
 }
 
@@ -261,10 +245,6 @@ func (c *Column) Trim() *sqlFunc {
     return Trim(c)
 }
 
-func (c *ColumnDef) Trim() *sqlFunc {
-    return Trim(c)
-}
-
 func CharLength(p projection) *sqlFunc {
     return &sqlFunc{
         scanInfo: funcScanTable[FUNC_CHAR_LENGTH],
@@ -274,10 +254,6 @@ func CharLength(p projection) *sqlFunc {
 }
 
 func (c *Column) CharLength() *sqlFunc {
-    return CharLength(c)
-}
-
-func (c *ColumnDef) CharLength() *sqlFunc {
     return CharLength(c)
 }
 
@@ -293,10 +269,6 @@ func (c *Column) BitLength() *sqlFunc {
     return BitLength(c)
 }
 
-func (c *ColumnDef) BitLength() *sqlFunc {
-    return BitLength(c)
-}
-
 func Ascii(p projection) *sqlFunc {
     return &sqlFunc{
         scanInfo: funcScanTable[FUNC_ASCII],
@@ -309,10 +281,6 @@ func (c *Column) Ascii() *sqlFunc {
     return Ascii(c)
 }
 
-func (c *ColumnDef) Ascii() *sqlFunc {
-    return Ascii(c)
-}
-
 func Reverse(p projection) *sqlFunc {
     return &sqlFunc{
         scanInfo: funcScanTable[FUNC_REVERSE],
@@ -322,10 +290,6 @@ func Reverse(p projection) *sqlFunc {
 }
 
 func (c *Column) Reverse() *sqlFunc {
-    return Reverse(c)
-}
-
-func (c *ColumnDef) Reverse() *sqlFunc {
     return Reverse(c)
 }
 

--- a/function.go
+++ b/function.go
@@ -1,9 +1,5 @@
 package sqlb
 
-import (
-    "fmt"
-)
-
 type funcId int
 
 const (
@@ -87,12 +83,6 @@ func (f *sqlFunc) disableAliasScan() func() {
     origAlias := f.alias
     f.alias = ""
     return func() {f.alias = origAlias}
-}
-
-func (f *sqlFunc) projectionId() uint64 {
-    // Each construction of a function is unique, so here we cheat and just
-    // return the hash of the struct's address in memory
-    return toId(fmt.Sprintf("%p", f))
 }
 
 func (f *sqlFunc) Alias(alias string) {

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -16,7 +16,7 @@ func TestGroupByClause(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
+    users := m.Table("users")
     colUserId := users.Column("id")
     colUserName := users.Column("name")
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -27,7 +27,6 @@ type element interface {
 // projection will not include the alias extension
 type projection interface {
     from() selection
-    projectionId() uint64
     // projections must also implement element
     size() int
     argCount() int

--- a/join.go
+++ b/join.go
@@ -16,10 +16,11 @@ type joinClause struct {
 }
 
 func (j *joinClause) argCount() int {
-    if j.on == nil {
-        return 0
+    ac := 0
+    if j.on != nil {
+        ac = j.on.argCount()
     }
-    return j.on.argCount()
+    return ac + j.left.argCount() + j.right.argCount()
 }
 
 func (j *joinClause) size() int {

--- a/join_test.go
+++ b/join_test.go
@@ -16,8 +16,8 @@ func TestJoinClause(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
-    articles := m.TableDef("articles")
+    users := m.Table("users")
+    articles := m.Table("articles")
     colUserId := users.Column("id")
     colArticleAuthor := articles.Column("author")
 
@@ -37,14 +37,14 @@ func TestJoinClause(t *testing.T) {
         },
         // articles to users tables
         joinClauseTest{
-            c: Join(articles.Table(), users.Table(), auCond),
+            c: Join(articles, users, auCond),
             qs: " JOIN users ON articles.author = users.id",
         },
         // join an aliased table to non-aliased table
         joinClauseTest{
             c: &joinClause{
                 left: articles.As("a"),
-                right: users.Table(),
+                right: users,
                 on: Equal(articles.As("a").Column("author"), colUserId),
             },
             qs: " JOIN users ON a.author = users.id",

--- a/meta_test.go
+++ b/meta_test.go
@@ -43,77 +43,77 @@ var (
 func testFixtureMeta() *Meta {
     meta := &Meta{
         schemaName: "test",
-        tdefs: make(map[string]*TableDef, 0),
+        tables: make(map[string]*Table, 0),
     }
 
-    users := &TableDef{
+    users := &Table{
         meta: meta,
         name: "users",
     }
-    colUserId := &ColumnDef{
+    colUserId := &Column{
         name: "id",
-        tdef: users,
+        tbl: users,
     }
-    colUserName := &ColumnDef{
+    colUserName := &Column{
         name: "name",
-        tdef: users,
+        tbl: users,
     }
 
-    articles := &TableDef{
+    articles := &Table{
         meta: meta,
         name: "articles",
     }
-    colArticleId := &ColumnDef{
+    colArticleId := &Column{
         name: "id",
-        tdef: articles,
+        tbl: articles,
     }
-    colArticleAuthor := &ColumnDef{
+    colArticleAuthor := &Column{
         name: "author",
-        tdef: articles,
+        tbl: articles,
     }
-    colArticleState := &ColumnDef{
+    colArticleState := &Column{
         name: "state",
-        tdef: articles,
+        tbl: articles,
     }
 
-    article_states := &TableDef{
+    articleStates := &Table{
         meta: meta,
         name: "article_states",
     }
-    colArticleStateId := &ColumnDef{
+    colArticleStateId := &Column{
         name: "id",
-        tdef: article_states,
+        tbl: articleStates,
     }
-    colArticleStateName := &ColumnDef{
+    colArticleStateName := &Column{
         name: "name",
-        tdef: article_states,
+        tbl: articleStates,
     }
 
-    user_profiles := &TableDef{
+    userProfiles := &Table{
         meta: meta,
         name: "user_profiles",
     }
-    colUserProfileId := &ColumnDef{
+    colUserProfileId := &Column{
         name: "id",
-        tdef: user_profiles,
+        tbl: userProfiles,
     }
-    colUserProfileContent := &ColumnDef{
+    colUserProfileContent := &Column{
         name: "content",
-        tdef: user_profiles,
+        tbl: userProfiles,
     }
-    colUserProfileUser := &ColumnDef{
+    colUserProfileUser := &Column{
         name: "user",
-        tdef: user_profiles,
+        tbl: userProfiles,
     }
 
-    users.cdefs = []*ColumnDef{colUserId, colUserName}
-    articles.cdefs = []*ColumnDef{colArticleId, colArticleAuthor, colArticleState}
-    article_states.cdefs = []*ColumnDef{colArticleStateId, colArticleStateName}
-    user_profiles.cdefs = []*ColumnDef{colUserProfileId, colUserProfileUser, colUserProfileContent}
-    meta.tdefs["users"] = users
-    meta.tdefs["articles"] = articles
-    meta.tdefs["article_states"] = article_states
-    meta.tdefs["user_profiles"] = user_profiles
+    users.columns = []*Column{colUserId, colUserName}
+    articles.columns = []*Column{colArticleId, colArticleAuthor, colArticleState}
+    articleStates.columns = []*Column{colArticleStateId, colArticleStateName}
+    userProfiles.columns = []*Column{colUserProfileId, colUserProfileUser, colUserProfileContent}
+    meta.tables["users"] = users
+    meta.tables["articles"] = articles
+    meta.tables["article_states"] = articleStates
+    meta.tables["user_profiles"] = userProfiles
     return meta
 }
 
@@ -147,20 +147,20 @@ func TestReflectMySQL(t *testing.T) {
     err = Reflect("mysql", db, &meta)
     assert.Nil(err)
 
-    assert.Equal(2, len(meta.tdefs))
+    assert.Equal(2, len(meta.tables))
 
-    artTbl := meta.tdefs["articles"]
-    userTbl := meta.tdefs["users"]
+    artTbl := meta.tables["articles"]
+    userTbl := meta.tables["users"]
 
     assert.Equal("articles", artTbl.name)
     assert.Equal("users", userTbl.name)
 
-    assert.Equal(7, len(userTbl.cdefs))
-    assert.Equal(5, len(artTbl.cdefs))
+    assert.Equal(7, len(userTbl.columns))
+    assert.Equal(5, len(artTbl.columns))
 
     createdOnCol := userTbl.Column("created_on")
     assert.NotNil(createdOnCol)
-    assert.Equal("created_on", createdOnCol.cdef.name)
+    assert.Equal("created_on", createdOnCol.name)
 }
 
 func TestReflectErrors(t *testing.T) {

--- a/order_by.go
+++ b/order_by.go
@@ -73,13 +73,6 @@ func (c *Column) Asc() *sortColumn {
     return &sortColumn{p: c}
 }
 
-func (c *ColumnDef) Desc() *sortColumn {
-    return &sortColumn{p: c, desc: true}
-}
-
-func (c *ColumnDef) Asc() *sortColumn {
-    return &sortColumn{p: c}
-}
 func (f *sqlFunc) Desc() *sortColumn {
     return &sortColumn{p: f, desc: true}
 }

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -16,9 +16,9 @@ func TestOrderBy(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
-    colUserId := users.ColumnDef("id")
-    colUserName := users.ColumnDef("name")
+    users := m.Table("users")
+    colUserId := users.Column("id")
+    colUserName := users.Column("name")
 
     tests := []orderByTest{
         // column def asc

--- a/select.go
+++ b/select.go
@@ -99,20 +99,15 @@ func (q *SelectQuery) Column(name string) projection {
             dc := p.(*derivedColumn)
             if dc.alias != "" && dc.alias == name {
                 return dc
-            } else if dc.c.cdef.name == name {
+            } else if dc.c.name == name {
                 return dc
             }
         case *Column:
             c := p.(*Column)
             if c.alias != "" && c.alias == name {
                 return c
-            } else if c.cdef.name == name {
+            } else if c.name == name {
                 return c
-            }
-        case *ColumnDef:
-            cd := p.(*ColumnDef)
-            if cd.name == name {
-                return cd
             }
         case *sqlFunc:
             f := p.(*sqlFunc)
@@ -318,20 +313,10 @@ func Select(items ...interface{}) *SelectQuery {
                 selectionMap[v.tbl] = true
             case *Table:
                 v := item.(*Table)
-                for _, cd := range v.tdef.projections() {
-                    addToProjections(sel, cd)
+                for _, c := range v.projections() {
+                    addToProjections(sel, c)
                 }
                 selectionMap[v] = true
-            case *TableDef:
-                v := item.(*TableDef)
-                for _, cd := range v.projections() {
-                    addToProjections(sel, cd)
-                }
-                selectionMap[v] = true
-            case *ColumnDef:
-                v := item.(*ColumnDef)
-                addToProjections(sel, v)
-                selectionMap[v.tdef] = true
             case *sqlFunc:
                 v := item.(*sqlFunc)
                 addToProjections(sel, v)

--- a/select.go
+++ b/select.go
@@ -260,7 +260,6 @@ func Select(items ...interface{}) *SelectQuery {
 
     nDerived := 0
     selectionMap := make(map[selection]bool, 0)
-    projectionMap := make(map[uint64]projection, 0)
 
     // For each scannable item we've received in the call, check what concrete
     // type they are and, depending on which type they are, either add them to
@@ -292,8 +291,6 @@ func Select(items ...interface{}) *SelectQuery {
                             selectionMap[innerSel] = true
                             dt := innerSel.(*derivedTable)
                             for _, p := range dt.getAllDerivedColumns() {
-                                pid := p.projectionId()
-                                projectionMap[pid] = p
                                 addToProjections(sel, p)
                             }
                         default:
@@ -310,8 +307,6 @@ func Select(items ...interface{}) *SelectQuery {
                             }
                             selectionMap[dt] = true
                             for _, p := range dt.getAllDerivedColumns() {
-                                pid := p.projectionId()
-                                projectionMap[pid] = p
                                 addToProjections(sel, p)
                             }
                             nDerived++

--- a/select_clause_test.go
+++ b/select_clause_test.go
@@ -16,16 +16,16 @@ func TestSelectClause(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
-    articles := m.TableDef("articles")
-    article_states := m.TableDef("article_states")
-    colUserName := users.ColumnDef("name")
-    colUserId := users.ColumnDef("id")
-    colArticleId := articles.ColumnDef("id")
-    colArticleAuthor := articles.ColumnDef("author")
-    colArticleState := articles.ColumnDef("state")
-    colArticleStateId := article_states.ColumnDef("id")
-    colArticleStateName := article_states.ColumnDef("name")
+    users := m.Table("users")
+    articles := m.Table("articles")
+    article_states := m.Table("article_states")
+    colUserName := users.Column("name")
+    colUserId := users.Column("id")
+    colArticleId := articles.Column("id")
+    colArticleAuthor := articles.Column("author")
+    colArticleState := articles.Column("state")
+    colArticleStateId := article_states.Column("id")
+    colArticleStateName := article_states.Column("name")
 
     tests := []selClauseTest{
         // a literal value
@@ -57,7 +57,7 @@ func TestSelectClause(t *testing.T) {
             qs: "SELECT ?, ?",
             qargs: []interface{}{1, 2},
         },
-        // TableDef and ColumnDef
+        // TableDef and Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users},
@@ -65,10 +65,10 @@ func TestSelectClause(t *testing.T) {
             },
             qs: "SELECT users.name FROM users",
         },
-        // Table and ColumnDef
+        // Table and Column
         selClauseTest{
             c: &selectClause{
-                selections: []selection{users.Table()},
+                selections: []selection{users},
                 projs: []projection{colUserName},
             },
             qs: "SELECT users.name FROM users",
@@ -91,7 +91,7 @@ func TestSelectClause(t *testing.T) {
             },
             qs: "SELECT u.name FROM users AS u",
         },
-        // TableDef and multiple ColumnDef
+        // TableDef and multiple Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users},
@@ -99,7 +99,7 @@ func TestSelectClause(t *testing.T) {
             },
             qs: "SELECT users.id, users.name FROM users",
         },
-        // TableDef and mixed Column and ColumnDef
+        // TableDef and mixed Column and Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users},

--- a/table.go
+++ b/table.go
@@ -2,32 +2,41 @@ package sqlb
 
 type Table struct {
     alias string
-    tdef *TableDef
+    meta *Meta
+    name string
+    columns []*Column
 }
 
+// Return a pointer to a Column with a name or alias matching the supplied
+// string, or nil if no such column is known
 func (t *Table) Column(name string) *Column {
-    for _, cdef := range t.tdef.cdefs {
-        if name == cdef.name {
-            return &Column{
-                tbl: t,
-                cdef: cdef,
-            }
+    for _, c := range t.columns {
+        if c.name == name || c.alias == name {
+            return c
         }
     }
     return nil
 }
 
-func (t *Table) projections() []projection {
-    cdefs := t.tdef.cdefs
-    ncols := len(cdefs)
-    cols := make([]projection, ncols)
-    for x := 0; x < ncols; x++ {
-        cols[x] = &Column{
-            tbl: t,
-            cdef: cdefs[x],
-        }
+func (t *Table) NewColumn(name string) *Column {
+    c := t.Column(name)
+    if c != nil {
+        return c
     }
-    return cols
+    c = &Column{
+        name: name,
+        tbl: t,
+    }
+    t.columns = append(t.columns, c)
+    return c
+}
+
+func (t *Table) projections() []projection {
+    res := make([]projection, len(t.columns))
+    for x, c := range t.columns {
+        res[x] = c
+    }
+    return res
 }
 
 func (t *Table) argCount() int {
@@ -35,7 +44,7 @@ func (t *Table) argCount() int {
 }
 
 func (t *Table) size() int {
-    size := t.tdef.size()
+    size := len(t.name)
     if t.alias != "" {
         size += len(Symbols[SYM_AS]) + len(t.alias)
     }
@@ -43,7 +52,7 @@ func (t *Table) size() int {
 }
 
 func (t *Table) scan(b []byte, args []interface{}) (int, int) {
-    bw, _ := t.tdef.scan(b, args)
+    bw := copy(b, t.name)
     if t.alias != "" {
         bw += copy(b[bw:], Symbols[SYM_AS])
         bw += copy(b[bw:], t.alias)
@@ -51,83 +60,20 @@ func (t *Table) scan(b []byte, args []interface{}) (int, int) {
     return bw, 0
 }
 
-func (t *Table) setAlias(alias string) {
-    t.alias = alias
-}
-
 func (t *Table) As(alias string) *Table {
-    t.setAlias(alias)
-    return t
-}
-
-type TableDef struct {
-    meta *Meta
-    name string
-    cdefs []*ColumnDef
-}
-
-func (td *TableDef) Table() *Table {
-    return &Table{tdef: td}
-}
-
-func (td *TableDef) argCount() int {
-    return 0
-}
-
-func (td *TableDef) size() int {
-    return len(td.name)
-}
-
-func (td *TableDef) scan(b []byte, args []interface{}) (int, int) {
-    return copy(b, td.name), 0
-}
-
-// Generate an aliased Table from a TableDef
-func (td *TableDef) As(alias string) *Table {
-    return &Table{tdef: td, alias: alias}
-}
-
-// Return a pointer to a ColumnDef with a name matching the supplied string, or
-// nil if no such column is known
-func (td *TableDef) ColumnDef(name string) *ColumnDef {
-    for _, cdef := range td.cdefs {
-        if cdef.name == name {
-            return cdef
+    cols := make([]*Column, len(t.columns))
+    tbl := &Table{
+        alias: alias,
+        name: t.name,
+        meta: t.meta,
+    }
+    for x, c := range t.columns {
+        cols[x] = &Column{
+            alias: c.alias,
+            name: c.name,
+            tbl: tbl,
         }
     }
-    return nil
-}
-
-func (td *TableDef) NewColumnDef(name string) *ColumnDef {
-    cd := td.ColumnDef(name)
-    if cd != nil {
-        return cd
-    }
-    cd = &ColumnDef{
-        name: name,
-        tdef: td,
-    }
-    td.cdefs = append(td.cdefs, cd)
-    return cd
-}
-
-// Returns a pointer to a Column representing an aliasable version of the table
-// column with the supplied name, or nil if no such column definition is known
-func (td *TableDef) Column(name string) *Column {
-    cd := td.ColumnDef(name)
-    if cd == nil {
-        return nil
-    }
-    return &Column{
-        cdef: cd,
-        tbl: td.Table(),
-    }
-}
-
-func (td *TableDef) projections() []projection {
-    res := make([]projection, len(td.cdefs))
-    for x, cdef := range td.cdefs {
-        res[x] = cdef
-    }
-    return res
+    tbl.columns = cols
+    return tbl
 }

--- a/table.go
+++ b/table.go
@@ -5,13 +5,6 @@ type Table struct {
     tdef *TableDef
 }
 
-func (t *Table) idParts() []string {
-    if t.alias != "" {
-        return []string{t.alias}
-    }
-    return t.tdef.idParts()
-}
-
 func (t *Table) Column(name string) *Column {
     for _, cdef := range t.tdef.cdefs {
         if name == cdef.name {
@@ -71,10 +64,6 @@ type TableDef struct {
     meta *Meta
     name string
     cdefs []*ColumnDef
-}
-
-func (td *TableDef) idParts() []string {
-    return []string{td.meta.schemaName, td.name}
 }
 
 func (td *TableDef) Table() *Table {

--- a/table_test.go
+++ b/table_test.go
@@ -10,21 +10,21 @@ func TestTableMeta(t *testing.T) {
     assert := assert.New(t)
 
     m := NewMeta("mysql", "test")
-    td := m.TableDef("users")
+    td := m.Table("users")
     assert.Nil(td)
-    td = m.NewTableDef("users")
+    td = m.NewTable("users")
     assert.NotNil(td)
     assert.Equal(td.meta, m)
 
-    assert.Equal(td, m.TableDef("users"))
+    assert.Equal(td, m.Table("users"))
 
-    cd := td.ColumnDef("id")
+    cd := td.Column("id")
     assert.Nil(cd)
 
-    cd = td.NewColumnDef("id")
+    cd = td.NewColumn("id")
     assert.NotNil(cd)
 
-    assert.Equal(cd, td.ColumnDef("id"))
+    assert.Equal(cd, td.Column("id"))
 }
 
 func TestTable(t *testing.T) {
@@ -63,51 +63,35 @@ func TestTableAlias(t *testing.T) {
     assert.Equal(exp, string(b))
 }
 
-func TestTableColumnDefs(t *testing.T) {
+func TestTableColumns(t *testing.T) {
     assert := assert.New(t)
 
-    td := &TableDef{
+    td := &Table{
         name: "users",
     }
 
-    cdefs := []*ColumnDef{
-         &ColumnDef{
+    cols := []*Column{
+         &Column{
             name: "id",
-            tdef: td,
+            tbl: td,
         },
-        &ColumnDef{
+        &Column{
             name: "email",
-            tdef: td,
+            tbl: td,
         },
     }
-    td.cdefs = cdefs
+    td.columns = cols
 
-    defs := td.cdefs
+    defs := td.columns
 
     assert.Equal(2, len(defs))
     for _, def := range defs {
-        assert.Equal(td, def.tdef)
+        assert.Equal(td, def.tbl)
     }
 
     // Check stable order of insertion from above...
     assert.Equal(defs[0].name, "id")
     assert.Equal(defs[1].name, "email")
-}
-
-func TestTableDefColumn(t *testing.T) {
-    assert := assert.New(t)
-
-    m := testFixtureMeta()
-    users := m.TableDef("users")
-
-    c := users.Column("name")
-
-    assert.Equal(users, c.cdef.tdef)
-    assert.Equal("name", c.cdef.name)
-
-    // Check an unknown column name returns nil
-    unknown := users.Column("unknown")
-    assert.Nil(unknown)
 }
 
 func TestTableColumn(t *testing.T) {
@@ -118,8 +102,8 @@ func TestTableColumn(t *testing.T) {
 
     c := users.Column("name")
 
-    assert.Equal(users.tdef, c.cdef.tdef)
-    assert.Equal("name", c.cdef.name)
+    assert.Equal(users, c.tbl)
+    assert.Equal("name", c.name)
 
     // Check an unknown column name returns nil
     unknown := users.Column("unknown")

--- a/where_test.go
+++ b/where_test.go
@@ -16,7 +16,7 @@ func TestWhereClause(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    users := m.TableDef("users")
+    users := m.Table("users")
     colUserId := users.Column("id")
     colUserName := users.Column("name")
 


### PR DESCRIPTION
Major overhaul of the way we represent table and column structs in sqlb. Gets
rid of the bifurcated Table/TableDef and Column/ColumnDef struct pairs and just
has a single Table and Column struct definition. When using Table.As() to
generate a new Table struct, we now copy all of the original Table struct's
columns and reference the new aliased Table struct in the cloned Column
structs.

This overhaul of the column/table metadata struct definitions enabled me to
debug what was going on in Issue #68. The derivedTable and Join structs were
not properly calculating argCount() by returning the argCount() of their
associated left, right, and from elements.

Fixes Issue #68
Closes Issue #69