### PR TITLE
Rename Table.Column() to Table.C()

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ func getArticles() []*Article {
     articles := meta.Table("articles")
     users := meta.Table("users")
 
-    q := sqlb.Select(articles.Column("title"), articles.Column("content"),
-                     articles.Column("created_by"), users.Column("name"))
-    q.Join(users, Equal(articles.Column("author"), users.Column("id)))
-    q.OrderBy(articles.Column("created_by").Desc())
+    q := sqlb.Select(articles.C("title"), articles.C("content"),
+                     articles.C("created_by"), users.C("name"))
+    q.Join(users, Equal(articles.C("author"), users.C("id)))
+    q.OrderBy(articles.C("created_by").Desc())
     q.Limit(10)
 
     articles := make([]*Article, 0)
@@ -286,13 +286,13 @@ func getArticles(numArticles int, byAuthor string) []*Articles {
     articles := meta.Table("articles")
     users := meta.Table("users")
 
-    q := sqlb.Select(articles.Column("title"), articles.Column("content"),
-                     articles.Column("created_by"), users.Column("name"))
-    q.Join(users, Equal(articles.Column("author"), users.Column("id)))
+    q := sqlb.Select(articles.C("title"), articles.C("content"),
+                     articles.C("created_by"), users.C("name"))
+    q.Join(users, Equal(articles.C("author"), users.C("id)))
     if byAuthor != "" {
-        q.Where(q.Equal(users.Column("name"), byAuthor))
+        q.Where(q.Equal(users.C("name"), byAuthor))
     }
-    q.OrderBy(articles.Column("created_by").Desc())
+    q.OrderBy(articles.C("created_by").Desc())
     q.Limit(numArticle)
 
     articles := make([]*Article, 0)

--- a/alias_test.go
+++ b/alias_test.go
@@ -10,7 +10,7 @@ func TestAsFunc(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    c := m.Table("users").Column("name")
+    c := m.Table("users").C("name")
 
     assert.Equal("", c.alias)
     As(c, "n")
@@ -28,7 +28,7 @@ func TestAsMethod(t *testing.T) {
     assert.Equal("", users.alias)
     u := users.As("u")
     assert.Equal("u", u.alias)
-    c := m.Table("users").Column("name")
+    c := m.Table("users").C("name")
     assert.Equal("", c.alias)
     c = c.As("n")
     assert.Equal("n", c.alias)

--- a/column_test.go
+++ b/column_test.go
@@ -6,11 +6,11 @@ import (
     "github.com/stretchr/testify/assert"
 )
 
-func TestColumn(t *testing.T) {
+func TestC(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    c := m.Table("users").Column("name")
+    c := m.Table("users").C("name")
 
     exp := "users.name"
     expLen := len(exp)
@@ -28,7 +28,7 @@ func TestColumnWithTableAlias(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    c := m.Table("users").As("u").Column("name")
+    c := m.Table("users").As("u").C("name")
 
     exp := "u.name"
     expLen := len(exp)
@@ -46,7 +46,7 @@ func TestColumnAlias(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
-    c := m.Table("users").Column("name").As("user_name")
+    c := m.Table("users").C("name").As("user_name")
 
     exp := "users.name AS user_name"
     expLen := len(exp)

--- a/derived_test.go
+++ b/derived_test.go
@@ -17,7 +17,7 @@ func TestDerived(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserName := users.Column("name")
+    colUserName := users.C("name")
 
     tests := []derivedTest{
         // Simple one-column sub-SELECT

--- a/docs/how-to/derived-tables.md
+++ b/docs/how-to/derived-tables.md
@@ -81,12 +81,12 @@ u := meta.Table("users")
 a := meta.Table("articles")
 c := meta.Table("comments")
 
-usersId := u.Column("id")
-articlesId := a.Column("id")
-articlesAuthor := a.Column("author")
-articlesIsAuthor := a.Column("is_author")
-commentsArticleId := c.Column("article_id")
-commentsCreatedOn := c.Column("created_on")
+usersId := u.C("id")
+articlesId := a.C("id")
+articlesAuthor := a.C("author")
+articlesIsAuthor := a.C("is_author")
+commentsArticleId := c.C("article_id")
+commentsCreatedOn := c.C("created_on")
 
 // First, build the subquery in the FROM clause (the derived table)
 subq := sqlb.Select(usersId).Join(a, sqlb.Equal(usersId, articlesAuthor))
@@ -97,6 +97,6 @@ subq.As("top_authors")
 
 // Next, build the outer SELECT on the comments table and join to the subselect
 q := sqlb.Select(c).Join(a, sqlb.Equal(commentsArticleId, articlesId))
-q.Join(subq, sqlb.Equal(articlesAuthor, subq.Column("id")))
+q.Join(subq, sqlb.Equal(articlesAuthor, subq.C("id")))
 q.OrderBy(commentsCreatedOn.Desc())
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -90,11 +90,11 @@ name of the table.
 A similar process is used to set metadata about a table's column definitions.
 The `sqlb.Column` struct defines the column name and links a pointer to
 the appropriate `Table` struct. To look up a particular column by its name,
-use the `sqlb.Table.Column()` method. If no such column is known, `nil`
+use the `sqlb.Table.C()` method. If no such column is known, `nil`
 will be returned:
 
 ```go
-    colUserId := users.Column("id")
+    colUserId := users.C("id")
     // colUserId == nil
 ```
 
@@ -269,7 +269,7 @@ If you want to count the number of distinct values of a column, use the
 
 ```go
     articles := meta.Table("articles")
-    q := sqlb.Select(sqlb.CountDistinct(articles.Column("author")))
+    q := sqlb.Select(sqlb.CountDistinct(articles.C("author")))
     qs, qargs := q.StringArgs()
 ```
 
@@ -289,7 +289,7 @@ as these examples show:
 
 ```go
     articles := meta.Table("articles")
-    q := sqlb.Select(sqlb.Min(articles.Column("created_on").As("earliest_article")))
+    q := sqlb.Select(sqlb.Min(articles.C("created_on").As("earliest_article")))
     qs, qargs := q.StringArgs()
 ```
 
@@ -306,10 +306,10 @@ projection of `SUM(od.amount) AS `total\_amount` in the resulting SQL string.
 ```go
     o := meta.Table("orders").As("o")
     od := meta.Table("order_details").As("od")
-    oId := o.Column("id")
-    oCustomer := o.Column("customer")
-    odOrderId := od.Column("order_id")
-    odAmount := od.Column("amount")
+    oId := o.C("id")
+    oCustomer := o.C("customer")
+    odOrderId := od.C("order_id")
+    odAmount := od.C("amount")
 
     q := sqlb.Select(
         oCustomer,

--- a/expression_test.go
+++ b/expression_test.go
@@ -18,9 +18,9 @@ func TestExpressions(t *testing.T) {
     m := testFixtureMeta()
     users := m.Table("users")
     articles := m.Table("articles")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
-    colArticleAuthor := articles.Column("author")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
+    colArticleAuthor := articles.C("author")
 
     tests := []expressionTest{
         // equal value

--- a/function_test.go
+++ b/function_test.go
@@ -17,7 +17,7 @@ func TestFunctions(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserName := users.Column("name")
+    colUserName := users.C("name")
 
     tests := []functionTest{
         // MAX column

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -17,8 +17,8 @@ func TestGroupByClause(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
 
     tests := []groupByClauseTest{
         // Single column

--- a/join_test.go
+++ b/join_test.go
@@ -18,8 +18,8 @@ func TestJoinClause(t *testing.T) {
     m := testFixtureMeta()
     users := m.Table("users")
     articles := m.Table("articles")
-    colUserId := users.Column("id")
-    colArticleAuthor := articles.Column("author")
+    colUserId := users.C("id")
+    colArticleAuthor := articles.C("author")
 
     auCond := Equal(colArticleAuthor, colUserId)
     uaCond := Equal(colUserId, colArticleAuthor)
@@ -45,7 +45,7 @@ func TestJoinClause(t *testing.T) {
             c: &joinClause{
                 left: articles.As("a"),
                 right: users,
-                on: Equal(articles.As("a").Column("author"), colUserId),
+                on: Equal(articles.As("a").C("author"), colUserId),
             },
             qs: " JOIN users ON a.author = users.id",
         },
@@ -54,7 +54,7 @@ func TestJoinClause(t *testing.T) {
             c: &joinClause{
                 left: articles,
                 right: users.As("u"),
-                on: Equal(colArticleAuthor, users.As("u").Column("id")),
+                on: Equal(colArticleAuthor, users.As("u").C("id")),
             },
             qs: " JOIN users AS u ON articles.author = u.id",
         },

--- a/list_test.go
+++ b/list_test.go
@@ -11,7 +11,7 @@ func TestListSingle(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserName := users.Column("name")
+    colUserName := users.C("name")
 
     cl := &List{elements: []element{colUserName}}
 
@@ -32,8 +32,8 @@ func TestListMulti(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
 
     cl := &List{elements: []element{colUserId, colUserName}}
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -158,7 +158,7 @@ func TestReflectMySQL(t *testing.T) {
     assert.Equal(7, len(userTbl.columns))
     assert.Equal(5, len(artTbl.columns))
 
-    createdOnCol := userTbl.Column("created_on")
+    createdOnCol := userTbl.C("created_on")
     assert.NotNil(createdOnCol)
     assert.Equal("created_on", createdOnCol.name)
 }

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -17,35 +17,21 @@ func TestOrderBy(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
 
     tests := []orderByTest{
-        // column def asc
+        // column asc
         orderByTest{
             c: &orderByClause{
                 scols: []*sortColumn{colUserName.Asc()},
             },
             qs: " ORDER BY users.name",
         },
-        // column asc
-        orderByTest{
-            c: &orderByClause{
-                scols: []*sortColumn{colUserName.Column().Asc()},
-            },
-            qs: " ORDER BY users.name",
-        },
-        // column def desc
-        orderByTest{
-            c: &orderByClause{
-                scols: []*sortColumn{colUserName.Desc()},
-            },
-            qs: " ORDER BY users.name DESC",
-        },
         // column desc
         orderByTest{
             c: &orderByClause{
-                scols: []*sortColumn{colUserName.Column().Desc()},
+                scols: []*sortColumn{colUserName.Desc()},
             },
             qs: " ORDER BY users.name DESC",
         },
@@ -59,7 +45,7 @@ func TestOrderBy(t *testing.T) {
         // multi column mixed
         orderByTest{
             c: &orderByClause{
-                scols: []*sortColumn{colUserName.Asc(), colUserId.Column().Desc()},
+                scols: []*sortColumn{colUserName.Asc(), colUserId.Desc()},
             },
             qs: " ORDER BY users.name, users.id DESC",
         },

--- a/select.go
+++ b/select.go
@@ -92,7 +92,7 @@ func (q *SelectQuery) As(alias string) *SelectQuery {
 
 // Returns the projection of the underlying selectClause that matches the name
 // provided
-func (q *SelectQuery) Column(name string) projection {
+func (q *SelectQuery) C(name string) projection {
     for _, p := range q.sel.projs {
         switch p.(type) {
         case *derivedColumn:

--- a/select_clause_test.go
+++ b/select_clause_test.go
@@ -19,13 +19,13 @@ func TestSelectClause(t *testing.T) {
     users := m.Table("users")
     articles := m.Table("articles")
     article_states := m.Table("article_states")
-    colUserName := users.Column("name")
-    colUserId := users.Column("id")
-    colArticleId := articles.Column("id")
-    colArticleAuthor := articles.Column("author")
-    colArticleState := articles.Column("state")
-    colArticleStateId := article_states.Column("id")
-    colArticleStateName := article_states.Column("name")
+    colUserName := users.C("name")
+    colUserId := users.C("id")
+    colArticleId := articles.C("id")
+    colArticleAuthor := articles.C("author")
+    colArticleState := articles.C("state")
+    colArticleStateId := article_states.C("id")
+    colArticleStateName := article_states.C("name")
 
     tests := []selClauseTest{
         // a literal value
@@ -57,14 +57,6 @@ func TestSelectClause(t *testing.T) {
             qs: "SELECT ?, ?",
             qargs: []interface{}{1, 2},
         },
-        // TableDef and Column
-        selClauseTest{
-            c: &selectClause{
-                selections: []selection{users},
-                projs: []projection{colUserName},
-            },
-            qs: "SELECT users.name FROM users",
-        },
         // Table and Column
         selClauseTest{
             c: &selectClause{
@@ -73,25 +65,17 @@ func TestSelectClause(t *testing.T) {
             },
             qs: "SELECT users.name FROM users",
         },
-        // TableDef and Column
-        selClauseTest{
-            c: &selectClause{
-                selections: []selection{users},
-                projs: []projection{colUserName.Column()},
-            },
-            qs: "SELECT users.name FROM users",
-        },
         // aliased Table and Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users.As("u")},
                 projs: []projection{
-                    users.As("u").Column("name"),
+                    users.As("u").C("name"),
                 },
             },
             qs: "SELECT u.name FROM users AS u",
         },
-        // TableDef and multiple Column
+        // Table and multiple Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users},
@@ -99,11 +83,11 @@ func TestSelectClause(t *testing.T) {
             },
             qs: "SELECT users.id, users.name FROM users",
         },
-        // TableDef and mixed Column and Column
+        // Table and mixed Column and Column
         selClauseTest{
             c: &selectClause{
                 selections: []selection{users},
-                projs: []projection{colUserId, colUserName.Column()},
+                projs: []projection{colUserId, colUserName},
             },
             qs: "SELECT users.id, users.name FROM users",
         },

--- a/select_test.go
+++ b/select_test.go
@@ -15,15 +15,15 @@ func TestSelectQuery(t *testing.T) {
     articles := m.Table("articles")
     articleStates := m.Table("article_states")
     userProfiles := m.Table("user_profiles")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
-    colArticleId := articles.Column("id")
-    colArticleAuthor := articles.Column("author")
-    colArticleState := articles.Column("state")
-    colArticleStateId := articleStates.Column("id")
-    colArticleStateName := articleStates.Column("name")
-    colUserProfileContent := userProfiles.Column("content")
-    colUserProfileUser := userProfiles.Column("user")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
+    colArticleId := articles.C("id")
+    colArticleAuthor := articles.C("author")
+    colArticleState := articles.C("state")
+    colArticleStateId := articleStates.C("id")
+    colArticleStateName := articleStates.C("name")
+    colUserProfileContent := userProfiles.C("content")
+    colUserProfileUser := userProfiles.C("user")
 
     subq := Select(colUserId).As("users_derived")
 
@@ -140,7 +140,7 @@ func TestSelectQuery(t *testing.T) {
             q: Select(
                 colUserId,
                 colUserName,
-            ).OuterJoin(subq, Equal(colUserId, subq.Column("id"))),
+            ).OuterJoin(subq, Equal(colUserId, subq.C("id"))),
             qs: "SELECT users.id, users.name FROM users LEFT JOIN (SELECT users.id FROM users) AS users_derived ON users.id = users_derived.id",
         },
         {
@@ -148,7 +148,7 @@ func TestSelectQuery(t *testing.T) {
             q: Select(
                 colUserId,
                 colUserName,
-            ).Join(subq, Equal(colUserId, subq.Column("id"))),
+            ).Join(subq, Equal(colUserId, subq.C("id"))),
             qs: "SELECT users.id, users.name FROM users JOIN (SELECT users.id FROM users) AS users_derived ON users.id = users_derived.id",
         },
         {
@@ -166,7 +166,7 @@ func TestSelectQuery(t *testing.T) {
             q: Select(
                 colUserId,
                 colUserName,
-            ).OuterJoin(subq, Equal(colUserId, subq.Column("id"))).Where(Equal(subq.Column("id"), 1)),
+            ).OuterJoin(subq, Equal(colUserId, subq.C("id"))).Where(Equal(subq.C("id"), 1)),
             qs: "SELECT users.id, users.name FROM users LEFT JOIN (SELECT users.id FROM users) AS users_derived ON users.id = users_derived.id WHERE users_derived.id = ?",
             qargs: []interface{}{1},
         },
@@ -218,13 +218,13 @@ func TestNestedSetQueries(t *testing.T) {
     o1 := orgs.As("o1")
     o2 := orgs.As("o2")
 
-    o1id := o1.Column("id")
-    o2id := o2.Column("id")
-    o1rootid := o1.Column("root_organization_id")
-    o2rootid := o2.Column("root_organization_id")
-    o1nestedleft := o1.Column("nested_set_left")
-    o2nestedleft := o2.Column("nested_set_left")
-    o2nestedright := o2.Column("nested_set_right")
+    o1id := o1.C("id")
+    o2id := o2.C("id")
+    o1rootid := o1.C("root_organization_id")
+    o2rootid := o2.C("root_organization_id")
+    o1nestedleft := o1.C("nested_set_left")
+    o2nestedleft := o2.C("nested_set_left")
+    o2nestedright := o2.C("nested_set_right")
 
     joinCond := And(
         Equal(o1rootid, o2rootid),
@@ -291,15 +291,15 @@ func TestNestedSetWithAdditionalJoin(t *testing.T) {
     o2 := orgs.As("o2")
     ou := orgUsers.As("ou")
 
-    o1id := o1.Column("id")
-    o2id := o2.Column("id")
-    o1rootid := o1.Column("root_organization_id")
-    o2rootid := o2.Column("root_organization_id")
-    o1nestedleft := o1.Column("nested_set_left")
-    o2nestedleft := o2.Column("nested_set_left")
-    o2nestedright := o2.Column("nested_set_right")
-    ouUserId := ou.Column("user_id")
-    ouOrgId := ou.Column("organization_id")
+    o1id := o1.C("id")
+    o2id := o2.C("id")
+    o1rootid := o1.C("root_organization_id")
+    o2rootid := o2.C("root_organization_id")
+    o1nestedleft := o1.C("nested_set_left")
+    o2nestedleft := o2.C("nested_set_left")
+    o2nestedright := o2.C("nested_set_right")
+    ouUserId := ou.C("user_id")
+    ouOrgId := ou.C("organization_id")
 
     nestedJoinCond := And(
         Equal(o1rootid, o2rootid),
@@ -397,15 +397,15 @@ func TestJoinDerivedWithMultipleSelections(t *testing.T) {
     o2 := orgs.As("o2")
     ou := orgUsers.As("ou")
 
-    o1id := o1.Column("id")
-    o2id := o2.Column("id")
-    o1rootid := o1.Column("root_organization_id")
-    o2rootid := o2.Column("root_organization_id")
-    o1nestedleft := o1.Column("nested_set_left")
-    o2nestedleft := o2.Column("nested_set_left")
-    o2nestedright := o2.Column("nested_set_right")
-    ouUserId := ou.Column("user_id")
-    ouOrgId := ou.Column("organization_id")
+    o1id := o1.C("id")
+    o2id := o2.C("id")
+    o1rootid := o1.C("root_organization_id")
+    o2rootid := o2.C("root_organization_id")
+    o1nestedleft := o1.C("nested_set_left")
+    o2nestedleft := o2.C("nested_set_left")
+    o2nestedright := o2.C("nested_set_right")
+    ouUserId := ou.C("user_id")
+    ouOrgId := ou.C("organization_id")
 
     nestedJoinCond := And(
         Equal(o1rootid, o2rootid),
@@ -416,7 +416,7 @@ func TestJoinDerivedWithMultipleSelections(t *testing.T) {
         Equal(ouUserId, 1),
     )
     subq := Select(o1id).Join(o2, nestedJoinCond).Join(ou, ouJoin).As("derived")
-    subqOrgId := subq.Column("id")
+    subqOrgId := subq.C("id")
 
     assert.Nil(subq.e)
 
@@ -429,11 +429,11 @@ func TestJoinDerivedWithMultipleSelections(t *testing.T) {
     assert.Equal(expqargs, qargs)
 
     q := Select(
-        orgs.Column("uuid"),
+        orgs.C("uuid"),
     ).OuterJoin(
         subq,
         Equal(
-            orgs.Column("id"),
+            orgs.C("id"),
             subqOrgId,
         ),
     ).Where(IsNotNull(subqOrgId))
@@ -462,7 +462,7 @@ func TestModifyingSelectQueryUpdatesBuffer(t *testing.T) {
     assert.Nil(qargs)
 
     // Modify the underlying SELECT and verify string and args changed
-    q.Where(Equal(users.Column("id"), 1))
+    q.Where(Equal(users.C("id"), 1))
     qs, qargs = q.StringArgs()
     assert.Equal("SELECT users.id, users.name FROM users WHERE users.id = ?", qs)
     assert.Equal([]interface{}{1}, qargs)

--- a/table.go
+++ b/table.go
@@ -9,7 +9,7 @@ type Table struct {
 
 // Return a pointer to a Column with a name or alias matching the supplied
 // string, or nil if no such column is known
-func (t *Table) Column(name string) *Column {
+func (t *Table) C(name string) *Column {
     for _, c := range t.columns {
         if c.name == name || c.alias == name {
             return c
@@ -19,7 +19,7 @@ func (t *Table) Column(name string) *Column {
 }
 
 func (t *Table) NewColumn(name string) *Column {
-    c := t.Column(name)
+    c := t.C(name)
     if c != nil {
         return c
     }

--- a/table_test.go
+++ b/table_test.go
@@ -18,13 +18,13 @@ func TestTableMeta(t *testing.T) {
 
     assert.Equal(td, m.Table("users"))
 
-    cd := td.Column("id")
+    cd := td.C("id")
     assert.Nil(cd)
 
     cd = td.NewColumn("id")
     assert.NotNil(cd)
 
-    assert.Equal(cd, td.Column("id"))
+    assert.Equal(cd, td.C("id"))
 }
 
 func TestTable(t *testing.T) {
@@ -94,18 +94,18 @@ func TestTableColumns(t *testing.T) {
     assert.Equal(defs[1].name, "email")
 }
 
-func TestTableColumn(t *testing.T) {
+func TestTableC(t *testing.T) {
     assert := assert.New(t)
 
     m := testFixtureMeta()
     users := m.Table("users")
 
-    c := users.Column("name")
+    c := users.C("name")
 
     assert.Equal(users, c.tbl)
     assert.Equal("name", c.name)
 
     // Check an unknown column name returns nil
-    unknown := users.Column("unknown")
+    unknown := users.C("unknown")
     assert.Nil(unknown)
 }

--- a/where_test.go
+++ b/where_test.go
@@ -17,8 +17,8 @@ func TestWhereClause(t *testing.T) {
 
     m := testFixtureMeta()
     users := m.Table("users")
-    colUserId := users.Column("id")
-    colUserName := users.Column("name")
+    colUserId := users.C("id")
+    colUserName := users.C("name")
 
     tests := []whereClauseTest{
         // Empty clause


### PR DESCRIPTION
The shorter C() method is conducive to easier-to-read and parse code

Close Issue #69