### PR TITLE
Add support for Insert() and Table.Insert()

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -1,0 +1,81 @@
+package sqlb
+
+import (
+    "errors"
+)
+
+var (
+    ERR_INSERT_NO_VALUES = errors.New("No values supplied.")
+    ERR_INSERT_UNKNOWN_COLUMN = errors.New("Received an unknown column.")
+)
+
+type InsertQuery struct {
+    e error
+    b []byte
+    args []interface{}
+    stmt *insertStatement
+}
+
+func (q *InsertQuery) IsValid() bool {
+    return q.e == nil &&  q.stmt != nil
+}
+
+func (q *InsertQuery) Error() error {
+    return q.e
+}
+
+func (q *InsertQuery) String() string {
+    size := q.stmt.size()
+    argc := q.stmt.argCount()
+    if len(q.args) != argc  {
+        q.args = make([]interface{}, argc)
+    }
+    if len(q.b) != size {
+        q.b = make([]byte, size)
+    }
+    q.stmt.scan(q.b, q.args)
+    return string(q.b)
+}
+
+func (q *InsertQuery) StringArgs() (string, []interface{}) {
+    size := q.stmt.size()
+    argc := q.stmt.argCount()
+    if len(q.args) != argc  {
+        q.args = make([]interface{}, argc)
+    }
+    if len(q.b) != size {
+        q.b = make([]byte, size)
+    }
+    q.stmt.scan(q.b, q.args)
+    return string(q.b), q.args
+}
+
+// Given a table and a map of column name to value for that column to insert,
+// returns an InsertQuery that will produce an INSERT SQL statement 
+func Insert(t *Table, values map[string]interface{}) *InsertQuery {
+    if len(values) == 0 {
+        return &InsertQuery{e: ERR_INSERT_NO_VALUES}
+    }
+
+    // Make sure all keys in the map point to actual columns in the target
+    // table.
+    cols := make([]*Column, len(values))
+    vals := make([]interface{}, len(values))
+    x := 0
+    for k, v := range values {
+        c := t.C(k)
+        if c == nil {
+            return &InsertQuery{e: ERR_INSERT_UNKNOWN_COLUMN}
+        }
+        cols[x] = c
+        vals[x] = v
+        x++
+    }
+
+    stmt := &insertStatement{
+        table: t,
+        columns: cols,
+        values: vals,
+    }
+    return &InsertQuery{stmt: stmt}
+}

--- a/insert.go
+++ b/insert.go
@@ -79,3 +79,7 @@ func Insert(t *Table, values map[string]interface{}) *InsertQuery {
     }
     return &InsertQuery{stmt: stmt}
 }
+
+func (t *Table) Insert(values map[string]interface{}) *InsertQuery {
+    return Insert(t, values)
+}

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -13,7 +13,7 @@ func (s *insertStatement) argCount() int {
 }
 
 func (s *insertStatement) size() int {
-    size := len(Symbols[SYM_INSERT]) + s.table.size() + 1 // space after table name
+    size := len(Symbols[SYM_INSERT]) + len(s.table.name) + 1 // space after table name
     ncols := len(s.columns)
     for _, c := range s.columns {
         // We don't add the table identifier or use an alias when outputting
@@ -32,9 +32,8 @@ func (s *insertStatement) size() int {
 func (s *insertStatement) scan(b []byte, args []interface{}) (int, int) {
     var bw, ac int
     bw += copy(b[bw:], Symbols[SYM_INSERT])
-    tbw, tac := s.table.scan(b[bw:], args[ac:])
-    bw += tbw
-    ac += tac
+    // We don't add any table alias when outputting the table identifier
+    bw += copy(b[bw:], s.table.name)
     bw += copy(b[bw:], " ")
     bw += copy(b[bw:], Symbols[SYM_LPAREN])
 

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -40,6 +40,16 @@ func TestInsertStatement(t *testing.T) {
             qs: "INSERT INTO users (id, name) VALUES (?, ?)",
             qargs: []interface{}{nil, "foo"},
         },
+        {
+            name: "Ensure no aliasing in column names",
+            s: &insertStatement{
+                table: users,
+                columns: []*Column{colUserId.As("user_id"), colUserName},
+                values: []interface{}{nil, "foo"},
+            },
+            qs: "INSERT INTO users (id, name) VALUES (?, ?)",
+            qargs: []interface{}{nil, "foo"},
+        },
     }
     for _, test := range tests {
         expLen := len(test.qs)

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -30,6 +30,16 @@ func TestInsertStatement(t *testing.T) {
             qs: "INSERT INTO users (id, name) VALUES (?, ?)",
             qargs: []interface{}{nil, "foo"},
         },
+        {
+            name: "Ensure no aliasing in table names",
+            s: &insertStatement{
+                table: users.As("u"),
+                columns: []*Column{colUserId, colUserName},
+                values: []interface{}{nil, "foo"},
+            },
+            qs: "INSERT INTO users (id, name) VALUES (?, ?)",
+            qargs: []interface{}{nil, "foo"},
+        },
     }
     for _, test := range tests {
         expLen := len(test.qs)

--- a/insert_test.go
+++ b/insert_test.go
@@ -1,0 +1,53 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestInsertQuery(t *testing.T) {
+    assert := assert.New(t)
+
+    m := testFixtureMeta()
+    users := m.Table("users")
+
+    tests := []struct{
+        name string
+        q *InsertQuery
+        qs string
+        qargs []interface{}
+        qe error
+    }{
+        {
+            name: "Values missing",
+            q: Insert(users, nil),
+            qe: ERR_INSERT_NO_VALUES,
+        },
+        {
+            name: "Unknown column",
+            q: Insert(users, map[string]interface{}{"unknown": 1}),
+            qe: ERR_INSERT_UNKNOWN_COLUMN,
+        },
+        {
+            name: "Simple INSERT",
+            q: Insert(users, map[string]interface{}{"id": 1}),
+            qs: "INSERT INTO users (id) VALUES (?)",
+            qargs: []interface{}{1},
+        },
+    }
+    for _, test := range tests {
+        if test.qe != nil {
+            assert.Equal(test.qe, test.q.Error())
+            continue
+        } else if test.q.Error() != nil {
+            qe := test.q.Error()
+            assert.Fail(qe.Error())
+            continue
+        }
+        qs, qargs := test.q.StringArgs()
+        assert.Equal(len(test.qargs), len(qargs))
+        assert.Equal(test.qs, qs)
+    }
+}
+

--- a/insert_test.go
+++ b/insert_test.go
@@ -35,6 +35,12 @@ func TestInsertQuery(t *testing.T) {
             qs: "INSERT INTO users (id) VALUES (?)",
             qargs: []interface{}{1},
         },
+        {
+            name: "INSERT using Table.Insert() adapter",
+            q: users.Insert(map[string]interface{}{"id": 1}),
+            qs: "INSERT INTO users (id) VALUES (?)",
+            qargs: []interface{}{1},
+        },
     }
     for _, test := range tests {
         if test.qe != nil {


### PR DESCRIPTION
Adds a new InsertQuery struct that implements the Query interface for INSERT SQL statements. Accepts a pointer to a Table struct along with a map of column name to value to be inserted.

Issue #67 