### PR TITLE
Implement UPDATE statement support

### DIFF
--- a/symbol.go
+++ b/symbol.go
@@ -24,6 +24,8 @@ const (
     SYM_INSERT
     SYM_DELETE
     SYM_VALUES
+    SYM_UPDATE
+    SYM_SET
     SYM_LPAREN
     SYM_RPAREN
     SYM_IN
@@ -79,8 +81,10 @@ var (
         SYM_LIMIT: []byte(" LIMIT "),
         SYM_OFFSET: []byte(" OFFSET "),
         SYM_INSERT: []byte("INSERT INTO "),
-        SYM_DELETE: []byte("DELETE FROM "),
         SYM_VALUES: []byte(") VALUES ("),
+        SYM_DELETE: []byte("DELETE FROM "),
+        SYM_UPDATE: []byte("UPDATE "),
+        SYM_SET: []byte(" SET "),
         SYM_LPAREN: []byte("("),
         SYM_RPAREN: []byte(")"),
         SYM_IN: []byte(" IN ("),

--- a/update.go
+++ b/update.go
@@ -1,0 +1,90 @@
+package sqlb
+
+import (
+    "errors"
+)
+
+var (
+    ERR_UPDATE_NO_TARGET = errors.New("No target table supplied.")
+    ERR_UPDATE_NO_VALUES = errors.New("No values supplied.")
+    ERR_UPDATE_UNKNOWN_COLUMN = errors.New("Received an unknown column.")
+)
+
+type UpdateQuery struct {
+    e error
+    b []byte
+    args []interface{}
+    stmt *updateStatement
+}
+
+func (q *UpdateQuery) IsValid() bool {
+    return q.e == nil &&  q.stmt != nil
+}
+
+func (q *UpdateQuery) Error() error {
+    return q.e
+}
+
+func (q *UpdateQuery) String() string {
+    size := q.stmt.size()
+    argc := q.stmt.argCount()
+    if len(q.args) != argc  {
+        q.args = make([]interface{}, argc)
+    }
+    if len(q.b) != size {
+        q.b = make([]byte, size)
+    }
+    q.stmt.scan(q.b, q.args)
+    return string(q.b)
+}
+
+func (q *UpdateQuery) StringArgs() (string, []interface{}) {
+    size := q.stmt.size()
+    argc := q.stmt.argCount()
+    if len(q.args) != argc  {
+        q.args = make([]interface{}, argc)
+    }
+    if len(q.b) != size {
+        q.b = make([]byte, size)
+    }
+    q.stmt.scan(q.b, q.args)
+    return string(q.b), q.args
+}
+
+func (q *UpdateQuery) Where(e *Expression) *UpdateQuery {
+    q.stmt.addWhere(e)
+    return q
+}
+
+// Given a table and a map of column name to value for that column to update,
+// returns an UpdateQuery that will produce an UPDATE SQL statement 
+func Update(t *Table, values map[string]interface{}) *UpdateQuery {
+    if t == nil {
+        return &UpdateQuery{e: ERR_UPDATE_NO_TARGET}
+    }
+    if len(values) == 0 {
+        return &UpdateQuery{e: ERR_UPDATE_NO_VALUES}
+    }
+
+    // Make sure all keys in the map point to actual columns in the target
+    // table.
+    cols := make([]*Column, len(values))
+    vals := make([]interface{}, len(values))
+    x := 0
+    for k, v := range values {
+        c := t.C(k)
+        if c == nil {
+            return &UpdateQuery{e: ERR_UPDATE_UNKNOWN_COLUMN}
+        }
+        cols[x] = c
+        vals[x] = v
+        x++
+    }
+
+    stmt := &updateStatement{
+        table: t,
+        columns: cols,
+        values: vals,
+    }
+    return &UpdateQuery{stmt: stmt}
+}

--- a/update_statement.go
+++ b/update_statement.go
@@ -1,0 +1,74 @@
+package sqlb
+
+// UPDATE <table> SET <column_value_list>[ WHERE <predicates>]
+
+type updateStatement struct {
+    table *Table
+    columns []*Column
+    values []interface{}
+    where *whereClause
+}
+
+func (s *updateStatement) argCount() int {
+    argc := len(s.values)
+    if s.where != nil {
+        argc += s.where.argCount()
+    }
+    return argc
+}
+
+func (s *updateStatement) size() int {
+    size := len(Symbols[SYM_UPDATE]) + len(s.table.name) + len(Symbols[SYM_SET])
+    ncols := len(s.columns)
+    for _, c := range s.columns {
+        // We don't add the table identifier or use an alias when outputting
+        // the column names in the <columns> element of the INSERT statement
+        size += len(c.name)
+    }
+    size += (len(Symbols[SYM_EQUAL]) + len(Symbols[SYM_QUEST_MARK])) * ncols
+    // Two comma-delimited lists of same number of elements (columns and
+    // values)
+    size += 2 * (len(Symbols[SYM_COMMA_WS]) * (ncols - 1))  // the commas...
+    if s.where != nil {
+        size += s.where.size()
+    }
+    return size
+}
+
+func (s *updateStatement) scan(b []byte, args []interface{}) (int, int) {
+    var bw, ac int
+    bw += copy(b[bw:], Symbols[SYM_UPDATE])
+    // We don't add any table alias when outputting the table identifier
+    bw += copy(b[bw:], s.table.name)
+    bw += copy(b[bw:], Symbols[SYM_SET])
+
+    ncols := len(s.columns)
+    for x, c := range s.columns {
+        // We don't add the table identifier or use an alias when outputting
+        // the column names in the <column_value_lists> element of the UPDATE
+        // statement
+        bw += copy(b[bw:], c.name)
+        bw += copy(b[bw:], Symbols[SYM_EQUAL])
+        bw += copy(b[bw:], Symbols[SYM_QUEST_MARK])
+        args[ac] = s.values[x]
+        ac++
+        if x != (ncols - 1) {
+            bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
+        }
+    }
+
+    if s.where != nil {
+        wbw, wac := s.where.scan(b[bw:], args[ac:])
+        bw += wbw
+        ac += wac
+    }
+    return bw, ac
+}
+
+func (s *updateStatement) addWhere(e *Expression) *updateStatement {
+    if s.where == nil {
+        s.where = &whereClause{filters: make([]*Expression, 0)}
+    }
+    s.where.filters = append(s.where.filters, e)
+    return s
+}

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -1,0 +1,62 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestUpdateStatement(t *testing.T) {
+    assert := assert.New(t)
+
+    m := testFixtureMeta()
+    users := m.Table("users")
+    colUserName := users.C("name")
+
+    tests := []struct{
+        name string
+        s *updateStatement
+        qs string
+        qargs []interface{}
+    }{
+        {
+            name: "UPDATE no WHERE",
+            s: &updateStatement{
+                table: users,
+                columns: []*Column{colUserName},
+                values: []interface{}{"foo"},
+            },
+            qs: "UPDATE users SET name = ?",
+            qargs: []interface{}{"foo"},
+        },
+        {
+            name: "UPDATE simple WHERE",
+            s: &updateStatement{
+                table: users,
+                columns: []*Column{colUserName},
+                values: []interface{}{"foo"},
+                where: &whereClause{
+                    filters: []*Expression{
+                        Equal(colUserName, "bar"),
+                    },
+                },
+            },
+            qs: "UPDATE users SET name = ? WHERE users.name = ?",
+            qargs: []interface{}{"foo", "bar"},
+        },
+    }
+    for _, test := range tests {
+        expLen := len(test.qs)
+        s := test.s.size()
+        assert.Equal(expLen, s)
+
+        expArgc := len(test.qargs)
+        assert.Equal(expArgc, test.s.argCount())
+
+        b := make([]byte, s)
+        written, _ := test.s.scan(b, test.qargs)
+
+        assert.Equal(written, s)
+        assert.Equal(test.qs, string(b))
+    }
+}

--- a/update_test.go
+++ b/update_test.go
@@ -1,0 +1,66 @@
+package sqlb
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestUpdateQuery(t *testing.T) {
+    assert := assert.New(t)
+
+    m := testFixtureMeta()
+    users := m.Table("users")
+    colUserName := users.C("name")
+
+    tests := []struct{
+        name string
+        q *UpdateQuery
+        qs string
+        qargs []interface{}
+        qe error
+    }{
+        {
+            name: "Values missing",
+            q: Update(users, nil),
+            qe: ERR_UPDATE_NO_VALUES,
+        },
+        {
+            name: "Target table missing",
+            q: Update(nil, map[string]interface{}{"name": "foo"}),
+            qe: ERR_UPDATE_NO_TARGET,
+        },
+        {
+            name: "Unknown column",
+            q: Update(users, map[string]interface{}{"unknown": 1}),
+            qe: ERR_UPDATE_UNKNOWN_COLUMN,
+        },
+        {
+            name: "UPDATE no WHERE",
+            q: Update(users, map[string]interface{}{"name": "foo"}),
+            qs: "UPDATE users SET name = ?",
+            qargs: []interface{}{"foo"},
+        },
+        {
+            name: "UPDATE simple WHERE",
+            q: Update(users, map[string]interface{}{"name": "bar"}).Where(
+                Equal(colUserName, "foo"),
+            ),
+            qs: "UPDATE users SET name = ? WHERE users.name = ?",
+            qargs: []interface{}{"bar", "foo"},
+        },
+    }
+    for _, test := range tests {
+        if test.qe != nil {
+            assert.Equal(test.qe, test.q.Error())
+            continue
+        } else if test.q.Error() != nil {
+            qe := test.q.Error()
+            assert.Fail(qe.Error())
+            continue
+        }
+        qs, qargs := test.q.StringArgs()
+        assert.Equal(len(test.qargs), len(qargs))
+        assert.Equal(test.qs, qs)
+    }
+}


### PR DESCRIPTION
Adds a new `sqlb.Update()` function that returns a pointer to an `UpdateQuery` struct. `UpdateQuery` implements the `sqlb.query` interface and produces an SQL string for the `UPDATE` SQL statement.

Issue #67