### PR TITLE
Support reflection for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ func main() {
     if db, err := sql.Open("mysql", DSN); err != nil {
         log.Fatal(err)
     }
-    if err := sqlb.Reflect("mysql", db, &meta); err != nil {
+    if err := sqlb.Reflect(sqlb.DIALECT_MYSQL, db, &meta); err != nil {
         log.Fatal(err)
     }
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -58,8 +58,8 @@ collection of metadata elements. This section demonstrates how you can do so.
 
 The `sqlb.Meta` struct can be used to house metadata about a database schema's
 tables, those tables' columns and relation information. You can create a new
-`sqlb.Meta` using the `sqlb.NewMeta()`function, passing in the name of the
-database driver and the name of the database schema:
+`sqlb.Meta` using the `sqlb.NewMeta()`function, passing in the database dialect
+and the name of the database schema:
 
 ```go
 import (
@@ -67,7 +67,7 @@ import (
 )
 
 func main() {
-    meta := sqlb.NewMeta("mysql", "blog")
+    meta := sqlb.NewMeta(sqlb.DIALECT_MYSQL, "blog")
 }
 ```
 
@@ -112,10 +112,9 @@ definition:
 ### Automatically discovering metadata
 
 The other method of establishing database metadata is to let `sqlb` do it for
-you. The `sqlb.Reflect()` function accepts three arguments: a string describing
-the `database/sql` driver name, a pointer to a `database/sql:DB` struct and a
-pointer to a `sqlb.Meta` struct that you wish to fill with metadata
-information.
+you. The `sqlb.Reflect()` function accepts three arguments: the database
+dialect in use, a pointer to a `database/sql:DB` struct and a pointer to a
+`sqlb.Meta` struct that you wish to fill with metadata information.
 
 The following code demonstrates how to use the `sqlb.Reflect()` function
 properly. We use a MySQL database instance, however simply change the
@@ -141,7 +140,7 @@ func main() {
     }
 
     // Next, ask sqlb.Reflect() to populate the metadata for the DB
-    if err := sqlb.Reflect("mysql", db, meta); err != nil {
+    if err := sqlb.Reflect(sqlb.DIALECT_MYSQL, db, meta); err != nil {
         log.Fatal(err)
     }
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -117,10 +117,10 @@ func testFixtureMeta() *Meta {
 	return meta
 }
 
-func resetDB(driver string, db *sql.DB) {
+func resetDB(dialect Dialect, db *sql.DB) {
 	var stmts []string
-	switch driver {
-	case "mysql":
+	switch dialect {
+	case DIALECT_MYSQL:
 		stmts = _MYSQL_DB_INIT
 	}
 	for _, stmt := range stmts {
@@ -141,10 +141,10 @@ func TestReflectMySQL(t *testing.T) {
 	db, err := sql.Open("mysql", dsn)
 	assert.Nil(err)
 
-	resetDB("mysql", db)
+	resetDB(DIALECT_MYSQL, db)
 
 	var meta Meta
-	err = Reflect("mysql", db, &meta)
+	err = Reflect(DIALECT_MYSQL, db, &meta)
 	assert.Nil(err)
 
 	assert.Equal(2, len(meta.tables))
@@ -166,7 +166,7 @@ func TestReflectMySQL(t *testing.T) {
 func TestReflectErrors(t *testing.T) {
 	assert := assert.New(t)
 
-	err := Reflect("mysql", nil, nil)
+	err := Reflect(DIALECT_MYSQL, nil, nil)
 	assert.NotNil(err)
 	assert.Equal(ERR_NO_META_STRUCT, err)
 }

--- a/table_test.go
+++ b/table_test.go
@@ -9,7 +9,7 @@ import (
 func TestTableMeta(t *testing.T) {
 	assert := assert.New(t)
 
-	m := NewMeta("mysql", "test")
+	m := NewMeta(DIALECT_MYSQL, "test")
 	td := m.Table("users")
 	assert.Nil(td)
 	td = m.NewTable("users")


### PR DESCRIPTION
Initial steps adding SQL dialect support
    
Changes the `sqlb.Meta` struct definition to contain a new dialect field
and updates the `sqlb.Reflect()` and `sqlb.NewMeta()` functions to
accept a Dialect enum/const value instead of a string representing the
DB driver name.
    
We'll hang dialect adaptation from this new field on the Meta struct,
allowing us to modify the output SQL buffer based on the dialect in the
meta.
    
Adds support for reflecting PostgreSQL database tables and columns in
`sqlb.Reflect()`. Since MySQL and PostgreSQL interpret the TABLE_CATALOG
and TABLE_SCHEMA columns of the INFORMATION_SCHEMA.TABLES view
differently and due to the use of different interpolation markers for
query parameters, needed to use slightly different queries against
I_S.TABLES and I_S.COLUMNS.

Issue #56 