### PR TITLE
Add support for dialect-specific interpolation

### DIFF
--- a/column.go
+++ b/column.go
@@ -39,7 +39,7 @@ func (c *Column) size() int {
 	return size
 }
 
-func (c *Column) scan(b []byte, args []interface{}) (int, int) {
+func (c *Column) scan(b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if c.tbl.alias != "" {
 		bw += copy(b[bw:], c.tbl.alias)
@@ -52,7 +52,7 @@ func (c *Column) scan(b []byte, args []interface{}) (int, int) {
 		bw += copy(b[bw:], Symbols[SYM_AS])
 		bw += copy(b[bw:], c.alias)
 	}
-	return bw, 0
+	return bw
 }
 
 func (c *Column) setAlias(alias string) {

--- a/column_test.go
+++ b/column_test.go
@@ -18,7 +18,7 @@ func TestC(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := c.scan(b, nil)
+	written := c.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -36,7 +36,7 @@ func TestColumnWithTableAlias(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := c.scan(b, nil)
+	written := c.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -54,7 +54,7 @@ func TestColumnAlias(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := c.scan(b, nil)
+	written := c.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/delete.go
+++ b/delete.go
@@ -9,10 +9,11 @@ var (
 )
 
 type DeleteQuery struct {
-	e    error
-	b    []byte
-	args []interface{}
-	stmt *deleteStatement
+	e       error
+	b       []byte
+	args    []interface{}
+	stmt    *deleteStatement
+	dialect Dialect
 }
 
 func (q *DeleteQuery) IsValid() bool {
@@ -26,26 +27,30 @@ func (q *DeleteQuery) Error() error {
 func (q *DeleteQuery) String() string {
 	size := q.stmt.size()
 	argc := q.stmt.argCount()
+	size += interpolationLength(q.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	q.stmt.scan(q.b, q.args)
+	curArg := 0
+	q.stmt.scan(q.b, q.args, &curArg)
 	return string(q.b)
 }
 
 func (q *DeleteQuery) StringArgs() (string, []interface{}) {
 	size := q.stmt.size()
 	argc := q.stmt.argCount()
+	size += interpolationLength(q.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	q.stmt.scan(q.b, q.args)
+	curArg := 0
+	q.stmt.scan(q.b, q.args, &curArg)
 	return string(q.b), q.args
 }
 

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -23,17 +23,15 @@ func (s *deleteStatement) size() int {
 	return size
 }
 
-func (s *deleteStatement) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (s *deleteStatement) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_DELETE])
 	// We don't add any table alias when outputting the table identifier
 	bw += copy(b[bw:], s.table.name)
 	if s.where != nil {
-		wbw, wac := s.where.scan(b[bw:], args[ac:])
-		bw += wbw
-		ac += wac
+		bw += s.where.scan(b[bw:], args, curArg)
 	}
-	return bw, ac
+	return bw
 }
 
 func (s *deleteStatement) addWhere(e *Expression) *deleteStatement {

--- a/delete_statement_test.go
+++ b/delete_statement_test.go
@@ -41,17 +41,20 @@ func TestDeleteStatement(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		expLen := len(test.qs)
-		s := test.s.size()
-		assert.Equal(expLen, s)
-
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.s.argCount())
+		argc := test.s.argCount()
+		assert.Equal(expArgc, argc)
 
-		b := make([]byte, s)
-		written, _ := test.s.scan(b, test.qargs)
+		expLen := len(test.qs)
+		size := test.s.size()
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
 
-		assert.Equal(written, s)
+		b := make([]byte, size)
+		curArg := 0
+		written := test.s.scan(b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))
 	}
 }

--- a/derived.go
+++ b/derived.go
@@ -57,16 +57,14 @@ func (dt *derivedTable) size() int {
 	return size
 }
 
-func (dt *derivedTable) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (dt *derivedTable) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_LPAREN])
-	sbw, sac := dt.from.scan(b[bw:], args[ac:])
-	bw += sbw
-	ac += sac
+	bw += dt.from.scan(b[bw:], args, curArg)
 	bw += copy(b[bw:], Symbols[SYM_RPAREN])
 	bw += copy(b[bw:], Symbols[SYM_AS])
 	bw += copy(b[bw:], dt.alias)
-	return bw, ac
+	return bw
 }
 
 // A derivedColumn is a type of projection that is produced from a derived
@@ -165,8 +163,8 @@ func (dc *derivedColumn) size() int {
 	return size
 }
 
-func (dc *derivedColumn) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (dc *derivedColumn) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], dc.dt.alias)
 	bw += copy(b[bw:], Symbols[SYM_PERIOD])
 	if dc.c.alias != "" {
@@ -178,5 +176,5 @@ func (dc *derivedColumn) scan(b []byte, args []interface{}) (int, int) {
 		bw += copy(b[bw:], Symbols[SYM_AS])
 		bw += copy(b[bw:], dc.alias)
 	}
-	return bw, ac
+	return bw
 }

--- a/derived_test.go
+++ b/derived_test.go
@@ -45,7 +45,8 @@ func TestDerived(t *testing.T) {
 		assert.Equal(expArgc, test.c.argCount())
 
 		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/expression.go
+++ b/expression.go
@@ -108,8 +108,8 @@ func (e *Expression) size() int {
 	return size
 }
 
-func (e *Expression) scan(b []byte, args []interface{}) (int, int) {
-	bw, ac := 0, 0
+func (e *Expression) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	elidx := 0
 	for _, sym := range e.scanInfo {
 		if sym == SYM_ELEMENT {
@@ -123,14 +123,12 @@ func (e *Expression) scan(b []byte, args []interface{}) (int, int) {
 				defer reset()
 			}
 			elidx++
-			ebw, eac := el.scan(b[bw:], args[ac:])
-			bw += ebw
-			ac += eac
+			bw += el.scan(b[bw:], args, curArg)
 		} else {
 			bw += copy(b[bw:], Symbols[sym])
 		}
 	}
-	return bw, ac
+	return bw
 }
 
 func Equal(left interface{}, right interface{}) *Expression {

--- a/expression_test.go
+++ b/expression_test.go
@@ -118,17 +118,20 @@ func TestExpressions(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		expLen := len(test.qs)
-		s := test.c.size()
-		assert.Equal(expLen, s)
-
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		argc := test.c.argCount()
+		assert.Equal(expArgc, argc)
 
-		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		expLen := len(test.qs)
+		size := test.c.size()
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
 
-		assert.Equal(written, s)
+		b := make([]byte, size)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))
 	}
 }

--- a/function.go
+++ b/function.go
@@ -153,8 +153,8 @@ func (f *sqlFunc) size() int {
 	return size
 }
 
-func (f *sqlFunc) scan(b []byte, args []interface{}) (int, int) {
-	bw, ac := 0, 0
+func (f *sqlFunc) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	elidx := 0
 	for _, sym := range f.scanInfo {
 		if sym == SYM_ELEMENT {
@@ -168,9 +168,7 @@ func (f *sqlFunc) scan(b []byte, args []interface{}) (int, int) {
 				defer reset()
 			}
 			elidx++
-			ebw, eac := el.scan(b[bw:], args[ac:])
-			bw += ebw
-			ac += eac
+			bw += el.scan(b[bw:], args, curArg)
 		} else {
 			bw += copy(b[bw:], Symbols[sym])
 		}
@@ -179,7 +177,7 @@ func (f *sqlFunc) scan(b []byte, args []interface{}) (int, int) {
 		bw += copy(b[bw:], Symbols[SYM_AS])
 		bw += copy(b[bw:], f.alias)
 	}
-	return bw, ac
+	return bw
 }
 
 func Max(p projection) *sqlFunc {

--- a/function_test.go
+++ b/function_test.go
@@ -127,17 +127,20 @@ func TestFunctions(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		expLen := len(test.qs)
-		s := test.c.size()
-		assert.Equal(expLen, s)
-
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		argc := test.c.argCount()
+		assert.Equal(expArgc, argc)
 
-		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		expLen := len(test.qs)
+		size := test.c.size()
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
 
-		assert.Equal(written, s)
+		b := make([]byte, size)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))
 	}
 }

--- a/group_by.go
+++ b/group_by.go
@@ -20,19 +20,17 @@ func (gb *groupByClause) size() int {
 	return size + (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (gb *groupByClause) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (gb *groupByClause) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_GROUP_BY])
 	ncols := len(gb.cols)
 	for x, c := range gb.cols {
 		reset := c.disableAliasScan()
 		defer reset()
-		ebw, eac := c.scan(b[bw:], args[ac:])
-		bw += ebw
-		ac += eac
+		bw += c.scan(b[bw:], args, curArg)
 		if x != (ncols - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}
 	}
-	return bw, ac
+	return bw
 }

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -52,7 +52,8 @@ func TestGroupByClause(t *testing.T) {
 		assert.Equal(expArgc, test.c.argCount())
 
 		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/insert.go
+++ b/insert.go
@@ -10,10 +10,11 @@ var (
 )
 
 type InsertQuery struct {
-	e    error
-	b    []byte
-	args []interface{}
-	stmt *insertStatement
+	e       error
+	b       []byte
+	args    []interface{}
+	stmt    *insertStatement
+	dialect Dialect
 }
 
 func (q *InsertQuery) IsValid() bool {
@@ -27,26 +28,30 @@ func (q *InsertQuery) Error() error {
 func (q *InsertQuery) String() string {
 	size := q.stmt.size()
 	argc := q.stmt.argCount()
+	size += interpolationLength(q.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	q.stmt.scan(q.b, q.args)
+	curArg := 0
+	q.stmt.scan(q.b, q.args, &curArg)
 	return string(q.b)
 }
 
 func (q *InsertQuery) StringArgs() (string, []interface{}) {
 	size := q.stmt.size()
 	argc := q.stmt.argCount()
+	size += interpolationLength(q.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	q.stmt.scan(q.b, q.args)
+	curArg := 0
+	q.stmt.scan(q.b, q.args, &curArg)
 	return string(q.b), q.args
 }
 

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -52,17 +52,20 @@ func TestInsertStatement(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		expLen := len(test.qs)
-		s := test.s.size()
-		assert.Equal(expLen, s)
-
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.s.argCount())
+		argc := test.s.argCount()
+		assert.Equal(expArgc, argc)
 
-		b := make([]byte, s)
-		written, _ := test.s.scan(b, test.qargs)
+		expLen := len(test.qs)
+		size := test.s.size()
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
 
-		assert.Equal(written, s)
+		b := make([]byte, size)
+		curArg := 0
+		written := test.s.scan(b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))
 	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,13 +7,10 @@ type element interface {
 	// Returns the number of interface{} arguments that the element will add to
 	// the slice of interface{} arguments passed to Scan()
 	argCount() int
-	// scan takes two slices -- one for the slice of bytes that the
-	// implementation should copy its string representation to and another for
-	// the slice of interface{} values that the element should add its
-	// arguments to -- and returns two ints, one for the number of bytes that
-	// it copied into the byte slice and another for the number of arguments
-	// copied into the arg slice
-	scan([]byte, []interface{}) (int, int)
+	// scan takes two slices and a pointer to an int. The first slice is a slice of bytes that the
+	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
+	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
+	scan([]byte, []interface{}, *int) int
 }
 
 // A projection is something that produces a scalar value. A column, column
@@ -26,7 +23,7 @@ type projection interface {
 	// projections must also implement element
 	size() int
 	argCount() int
-	scan([]byte, []interface{}) (int, int)
+	scan([]byte, []interface{}, *int) int
 	// disables the outputting of the "AS alias" extended output. Returns a
 	// function that resets the outputting of the "AS alias" extended output
 	disableAliasScan() func()
@@ -39,7 +36,7 @@ type selection interface {
 	// selections must also implement element
 	size() int
 	argCount() int
-	scan([]byte, []interface{}) (int, int)
+	scan([]byte, []interface{}, *int) int
 }
 
 // A Query is a placeholder for something that can be asked for the SQL string

--- a/join.go
+++ b/join.go
@@ -41,8 +41,8 @@ func (j *joinClause) size() int {
 	return size
 }
 
-func (j *joinClause) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (j *joinClause) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	switch j.joinType {
 	case JOIN_INNER:
 		bw += copy(b[bw:], Symbols[SYM_JOIN])
@@ -51,16 +51,12 @@ func (j *joinClause) scan(b []byte, args []interface{}) (int, int) {
 	case JOIN_CROSS:
 		bw += copy(b[bw:], Symbols[SYM_CROSS_JOIN])
 	}
-	pbw, pac := j.right.scan(b[bw:], args)
-	bw += pbw
-	ac += pac
+	bw += j.right.scan(b[bw:], args, curArg)
 	if j.on != nil {
 		bw += copy(b[bw:], Symbols[SYM_ON])
-		fbw, fac := j.on.scan(b[bw:], args[ac:])
-		bw += fbw
-		ac += fac
+		bw += j.on.scan(b[bw:], args, curArg)
 	}
-	return bw, ac
+	return bw
 }
 
 func Join(left selection, right selection, on *Expression) *joinClause {

--- a/join_test.go
+++ b/join_test.go
@@ -106,7 +106,8 @@ func TestJoinClause(t *testing.T) {
 		assert.Equal(expArgc, test.c.argCount())
 
 		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/limit.go
+++ b/limit.go
@@ -1,8 +1,9 @@
 package sqlb
 
 type limitClause struct {
-	limit  int
-	offset *int
+	limit   int
+	offset  *int
+	dialect Dialect
 }
 
 func (lc *limitClause) argCount() int {
@@ -13,24 +14,28 @@ func (lc *limitClause) argCount() int {
 }
 
 func (lc *limitClause) size() int {
-	size := len(Symbols[SYM_LIMIT]) + len(Symbols[SYM_QUEST_MARK])
+	// Due to dialect handling, we do not include the length of interpolation
+	// markers for query parameters. This is calculated separately by the
+	// top-level scanning struct before malloc'ing the buffer to inject the SQL
+	// string into.
+	size := len(Symbols[SYM_LIMIT])
 	if lc.offset != nil {
-		size += len(Symbols[SYM_OFFSET]) + len(Symbols[SYM_QUEST_MARK])
+		size += len(Symbols[SYM_OFFSET])
 	}
 	return size
 }
 
-func (lc *limitClause) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (lc *limitClause) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_LIMIT])
-	bw += copy(b[bw:], Symbols[SYM_QUEST_MARK])
-	args[ac] = lc.limit
-	ac++
+	bw += scanInterpolationMarker(lc.dialect, b[bw:], *curArg)
+	args[*curArg] = lc.limit
+	*curArg++
 	if lc.offset != nil {
 		bw += copy(b[bw:], Symbols[SYM_OFFSET])
-		bw += copy(b[bw:], Symbols[SYM_QUEST_MARK])
-		args[ac] = *lc.offset
-		ac++
+		bw += scanInterpolationMarker(lc.dialect, b[bw:], *curArg)
+		args[*curArg] = *lc.offset
+		*curArg++
 	}
-	return bw, ac
+	return bw
 }

--- a/limit_test.go
+++ b/limit_test.go
@@ -6,59 +6,63 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestlimitClause(t *testing.T) {
+func TestLimitClause(t *testing.T) {
 	assert := assert.New(t)
 
 	lc := &limitClause{
-		limit: 20,
+		limit:   20,
+		dialect: DIALECT_MYSQL,
 	}
 
 	exp := " LIMIT ?"
-	expLen := len(exp)
 	expArgCount := 1
-
-	s := lc.size()
-	assert.Equal(expLen, s)
 
 	argc := lc.argCount()
 	assert.Equal(expArgCount, argc)
 
-	args := make([]interface{}, expArgCount)
-	b := make([]byte, s)
-	written, numArgs := lc.scan(b, args)
+	size := lc.size()
+	size += interpolationLength(DIALECT_MYSQL, argc)
+	expLen := len(exp)
+	assert.Equal(expLen, size)
 
-	assert.Equal(s, written)
+	args := make([]interface{}, expArgCount)
+	b := make([]byte, size)
+	curArg := 0
+	written := lc.scan(b, args, &curArg)
+
+	assert.Equal(size, written)
 	assert.Equal(exp, string(b))
-	assert.Equal(expArgCount, numArgs)
 	assert.Equal(20, args[0])
 }
 
-func TestlimitClauseWithOffset(t *testing.T) {
+func TestLimitClauseWithOffset(t *testing.T) {
 	assert := assert.New(t)
 
 	lc := &limitClause{
-		limit: 20,
+		limit:   20,
+		dialect: DIALECT_MYSQL,
 	}
 	offset := 10
 	lc.offset = &offset
 
 	exp := " LIMIT ? OFFSET ?"
-	expLen := len(exp)
 	expArgCount := 2
-
-	s := lc.size()
-	assert.Equal(expLen, s)
 
 	argc := lc.argCount()
 	assert.Equal(expArgCount, argc)
 
-	args := make([]interface{}, expArgCount)
-	b := make([]byte, s)
-	written, numArgs := lc.scan(b, args)
+	size := lc.size()
+	size += interpolationLength(DIALECT_MYSQL, argc)
+	expLen := len(exp)
+	assert.Equal(expLen, size)
 
-	assert.Equal(s, written)
+	args := make([]interface{}, expArgCount)
+	b := make([]byte, size)
+	curArg := 0
+	written := lc.scan(b, args, &curArg)
+
+	assert.Equal(size, written)
 	assert.Equal(exp, string(b))
-	assert.Equal(expArgCount, numArgs)
 	assert.Equal(20, args[0])
 	assert.Equal(10, args[1])
 }

--- a/list.go
+++ b/list.go
@@ -23,16 +23,14 @@ func (l *List) size() int {
 	return size + (len(Symbols[SYM_COMMA_WS]) * (nels - 1)) // the commas...
 }
 
-func (l *List) scan(b []byte, args []interface{}) (int, int) {
-	bw, ac := 0, 0
+func (l *List) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	nels := len(l.elements)
 	for x, el := range l.elements {
-		ebw, eac := el.scan(b[bw:], args[ac:])
-		bw += ebw
+		bw += el.scan(b[bw:], args, curArg)
 		if x != (nels - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}
-		ac += eac
 	}
-	return bw, ac
+	return bw
 }

--- a/list_test.go
+++ b/list_test.go
@@ -21,7 +21,7 @@ func TestListSingle(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := cl.scan(b, nil)
+	written := cl.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -43,7 +43,7 @@ func TestListMulti(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := cl.scan(b, nil)
+	written := cl.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/meta.go
+++ b/meta.go
@@ -8,13 +8,6 @@ import (
 	_ "github.com/lib/pq"
 )
 
-type Dialect int
-
-const (
-	DIALECT_MYSQL = iota
-	DIALECT_POSTGRESQL
-)
-
 var (
 	ERR_NO_META_STRUCT = errors.New("Please pass a pointer to a sqlb.Meta struct")
 )

--- a/order_by.go
+++ b/order_by.go
@@ -19,17 +19,15 @@ func (sc *sortColumn) size() int {
 	return size
 }
 
-func (sc *sortColumn) scan(b []byte, args []interface{}) (int, int) {
+func (sc *sortColumn) scan(b []byte, args []interface{}, curArg *int) int {
 	reset := sc.p.disableAliasScan()
 	defer reset()
-	var bw, ac int
-	ebw, eac := sc.p.scan(b[bw:], args[ac:])
-	bw += ebw
-	ac += eac
+	bw := 0
+	bw += sc.p.scan(b[bw:], args, curArg)
 	if sc.desc {
 		bw += copy(b[bw:], Symbols[SYM_DESC])
 	}
-	return bw, ac
+	return bw
 }
 
 type orderByClause struct {
@@ -50,19 +48,17 @@ func (ob *orderByClause) size() int {
 	return size + (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (ob *orderByClause) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (ob *orderByClause) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_ORDER_BY])
 	ncols := len(ob.scols)
 	for x, sc := range ob.scols {
-		ebw, eac := sc.scan(b[bw:], args[ac:])
-		bw += ebw
-		ac += eac
+		bw += sc.scan(b[bw:], args, curArg)
 		if x != (ncols - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}
 	}
-	return bw, ac
+	return bw
 }
 
 func (c *Column) Desc() *sortColumn {

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -66,7 +66,8 @@ func TestOrderBy(t *testing.T) {
 		assert.Equal(expArgc, test.c.argCount())
 
 		b := make([]byte, s)
-		written, _ := test.c.scan(b, test.qargs)
+		curArg := 0
+		written := test.c.scan(b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/symbol.go
+++ b/symbol.go
@@ -6,6 +6,7 @@ type scanInfo []Symbol
 const (
 	SYM_ELEMENT = iota // Marker for an element that self-scans into the SQL buffer
 	SYM_QUEST_MARK
+	SYM_DOLLAR
 	SYM_PERIOD
 	SYM_AS
 	SYM_COMMA_WS
@@ -169,6 +170,7 @@ var (
 var (
 	Symbols = map[Symbol][]byte{
 		SYM_QUEST_MARK:              []byte("?"),
+		SYM_DOLLAR:                  []byte("$"),
 		SYM_PERIOD:                  []byte("."),
 		SYM_AS:                      []byte(" AS "),
 		SYM_COMMA_WS:                []byte(", "),

--- a/table.go
+++ b/table.go
@@ -51,13 +51,13 @@ func (t *Table) size() int {
 	return size
 }
 
-func (t *Table) scan(b []byte, args []interface{}) (int, int) {
+func (t *Table) scan(b []byte, args []interface{}, curArg *int) int {
 	bw := copy(b, t.name)
 	if t.alias != "" {
 		bw += copy(b[bw:], Symbols[SYM_AS])
 		bw += copy(b[bw:], t.alias)
 	}
-	return bw, 0
+	return bw
 }
 
 func (t *Table) As(alias string) *Table {

--- a/table_test.go
+++ b/table_test.go
@@ -39,7 +39,7 @@ func TestTable(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := users.scan(b, nil)
+	written := users.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -57,7 +57,7 @@ func TestTableAlias(t *testing.T) {
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written, _ := u.scan(b, nil)
+	written := u.scan(b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -46,17 +46,20 @@ func TestUpdateStatement(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		expLen := len(test.qs)
-		s := test.s.size()
-		assert.Equal(expLen, s)
-
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.s.argCount())
+		argc := test.s.argCount()
+		assert.Equal(expArgc, argc)
 
-		b := make([]byte, s)
-		written, _ := test.s.scan(b, test.qargs)
+		expLen := len(test.qs)
+		size := test.s.size()
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
 
-		assert.Equal(written, s)
+		b := make([]byte, size)
+		curArg := 0
+		written := test.s.scan(b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -23,10 +23,10 @@ func Testvalue(t *testing.T) {
 
 	args := make([]interface{}, 1)
 	b := make([]byte, s)
-	written, numArgs := v.scan(b, args)
+	curArg := 0
+	written := v.scan(b, args, &curArg)
 
 	assert.Equal(s, written)
 	assert.Equal(exp, string(b))
 	assert.Equal("foo", args[0])
-	assert.Equal(expArgCount, numArgs)
 }

--- a/where.go
+++ b/where.go
@@ -25,18 +25,16 @@ func (w *whereClause) size() int {
 	return size
 }
 
-func (w *whereClause) scan(b []byte, args []interface{}) (int, int) {
-	var bw, ac int
+func (w *whereClause) scan(b []byte, args []interface{}, curArg *int) int {
+	bw := 0
 	if len(w.filters) > 0 {
 		bw += copy(b[bw:], Symbols[SYM_WHERE])
 		for x, filter := range w.filters {
 			if x > 0 {
 				bw += copy(b[bw:], Symbols[SYM_AND])
 			}
-			fbw, fac := filter.scan(b[bw:], args[ac:])
-			bw += fbw
-			ac += fac
+			bw += filter.scan(b[bw:], args, curArg)
 		}
 	}
-	return bw, ac
+	return bw
 }


### PR DESCRIPTION
Major overhaul of the scan() interface in order to support
dialect-specific interpolation markers. Because PostgreSQL and other
RDBMS do not use the ? character for query parameter interpolation and
instead use a marker of $N, where N starts at 1, this means that the
[]byte buffer we use to inject the SQL string contents needs to expand
or contract slightly depending on the SQL dialect in use.

This patch changes the scan() interface from:

 scan([]byte, []interface{}) (int, int)

to:

 scan([]byte, []interface{}, *int) int

This change allowed me to pass a positional index for the argument
(which gets converted into a SQL dialect-specific interpolation marker
for each query parameter in the args slice) to a new
interpolationMarker() function that understands how to inject the
appropriate interpolation characters into the []byte buffer containing
the end SQL string.

Still need to add corresponding tests for PostgreSQL-specific string
output.

Issue #56