### PR TITLE
Start process of adding dialect support to SQL functions

### DIFF
--- a/column.go
+++ b/column.go
@@ -1,9 +1,16 @@
 package sqlb
 
 type Column struct {
-	alias string
-	name  string
-	tbl   *Table
+	alias   string
+	name    string
+	tbl     *Table
+	dialect Dialect
+}
+
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (c *Column) setDialect(dialect Dialect) {
+	c.dialect = dialect
 }
 
 func (c *Column) from() selection {

--- a/derived.go
+++ b/derived.go
@@ -16,7 +16,7 @@ package sqlb
 // of the derived table as the selection alias (u instead of users).
 type derivedTable struct {
 	alias string
-	from  *selectClause
+	from  *selectStatement
 }
 
 // Return a collection of derivedColumn projections that have been constructed

--- a/derived.go
+++ b/derived.go
@@ -19,6 +19,10 @@ type derivedTable struct {
 	from  *selectStatement
 }
 
+func (dt *derivedTable) setDialect(dialect Dialect) {
+	dt.from.setDialect(dialect)
+}
+
 // Return a collection of derivedColumn projections that have been constructed
 // to refer to this derived table and not have any outer alias
 func (dt *derivedTable) getAllDerivedColumns() []projection {
@@ -120,6 +124,11 @@ type derivedColumn struct {
 	alias string // This is the outermost alias
 	c     *Column
 	dt    *derivedTable
+}
+
+func (dc *derivedColumn) setDialect(dialect Dialect) {
+	dc.c.setDialect(dialect)
+	dc.dt.setDialect(dialect)
 }
 
 func (dc *derivedColumn) from() selection {

--- a/derived_test.go
+++ b/derived_test.go
@@ -23,7 +23,7 @@ func TestDerived(t *testing.T) {
 		// Simple one-column sub-SELECT
 		derivedTest{
 			c: &derivedTable{
-				from: &selectClause{
+				from: &selectStatement{
 					projs: []projection{
 						colUserName,
 					},

--- a/expression.go
+++ b/expression.go
@@ -63,6 +63,16 @@ var (
 type Expression struct {
 	scanInfo scanInfo
 	elements []element
+	dialect  Dialect
+}
+
+// Sets the Expression's dialect and pushes the dialect down into any of the
+// Expression's elements
+func (e *Expression) setDialect(dialect Dialect) {
+	e.dialect = dialect
+	for _, el := range e.elements {
+		el.setDialect(dialect)
+	}
 }
 
 func (e *Expression) referrents() []selection {

--- a/function.go
+++ b/function.go
@@ -97,6 +97,7 @@ type sqlFunc struct {
 	alias    string
 	scanInfo scanInfo
 	elements []element
+	dialect  Dialect
 }
 
 func (f *sqlFunc) from() selection {

--- a/function.go
+++ b/function.go
@@ -100,6 +100,19 @@ type sqlFunc struct {
 	dialect  Dialect
 }
 
+// Sets the sqlFunc's dialect and pushes the dialect down into any of the
+// sqlFunc's elements
+func (f *sqlFunc) setDialect(dialect Dialect) {
+	f.dialect = dialect
+	for _, el := range f.elements {
+		switch el.(type) {
+		case *value:
+			v := el.(*value)
+			v.dialect = dialect
+		}
+	}
+}
+
 func (f *sqlFunc) from() selection {
 	return f.sel
 }

--- a/function.go
+++ b/function.go
@@ -10,7 +10,6 @@ const (
 	FUNC_COUNT_STAR
 	FUNC_COUNT_DISTINCT
 	FUNC_CAST
-	FUNC_TRIM
 	FUNC_CHAR_LENGTH
 	FUNC_BIT_LENGTH
 	FUNC_ASCII
@@ -48,9 +47,6 @@ var (
 		},
 		FUNC_CAST: scanInfo{
 			SYM_CAST, SYM_ELEMENT, SYM_AS, SYM_PLACEHOLDER, SYM_RPAREN,
-		},
-		FUNC_TRIM: scanInfo{
-			SYM_TRIM, SYM_ELEMENT, SYM_RPAREN,
 		},
 		FUNC_CHAR_LENGTH: scanInfo{
 			SYM_CHAR_LENGTH, SYM_ELEMENT, SYM_RPAREN,
@@ -267,18 +263,6 @@ func Cast(p projection, stype SqlType) *sqlFunc {
 		scanInfo: si,
 		elements: []element{p.(element)},
 	}
-}
-
-func Trim(p projection) *sqlFunc {
-	return &sqlFunc{
-		scanInfo: funcScanTable[FUNC_TRIM],
-		elements: []element{p.(element)},
-		sel:      p.from(),
-	}
-}
-
-func (c *Column) Trim() *sqlFunc {
-	return Trim(c)
 }
 
 func CharLength(p projection) *sqlFunc {

--- a/function_test.go
+++ b/function_test.go
@@ -92,16 +92,6 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 		{
-			name: "TRIM(column)",
-			c:    Trim(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL: "TRIM(users.name)",
-				// Should be:
-				// DIALECT_POSTGRESQL: "BTRIM(users.name)",
-				DIALECT_POSTGRESQL: "TRIM(users.name)",
-			},
-		},
-		{
 			name: "CHAR_LENGTH(column)",
 			c:    CharLength(colUserName),
 			qs: map[Dialect]string{

--- a/function_test.go
+++ b/function_test.go
@@ -201,7 +201,7 @@ func TestFunctions(t *testing.T) {
 
 		// Test each SQL dialect output
 		for dialect, qs := range test.qs {
-			test.c.dialect = dialect
+			test.c.setDialect(dialect)
 			expLen := len(qs)
 			size := test.c.size()
 			size += interpolationLength(dialect, argc)

--- a/function_test.go
+++ b/function_test.go
@@ -16,114 +16,156 @@ func TestFunctions(t *testing.T) {
 	tests := []struct {
 		name  string
 		c     *sqlFunc
-		qs    string
+		qs    map[Dialect]string
 		qargs []interface{}
 	}{
 		{
 			name: "MAX(column)",
 			c:    Max(colUserName),
-			qs:   "MAX(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "MAX(users.name)",
+			},
 		},
 		{
 			name: "aliased function",
 			c:    Max(colUserName).As("max_name"),
-			qs:   "MAX(users.name) AS max_name",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "MAX(users.name) AS max_name",
+			},
 		},
 		{
 			name: "MIN(column)",
 			c:    Min(colUserName),
-			qs:   "MIN(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "MIN(users.name)",
+			},
 		},
 		{
 			name: "SUM(column)",
 			c:    Sum(colUserName),
-			qs:   "SUM(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "SUM(users.name)",
+			},
 		},
 		{
 			name: "AVG(column)",
 			c:    Avg(colUserName),
-			qs:   "AVG(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "AVG(users.name)",
+			},
 		},
 		{
 			name: "COUNT(*)",
 			c:    Count(users),
-			qs:   "COUNT(*)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "COUNT(*)",
+			},
 		},
 		{
 			name: "COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName),
-			qs:   "COUNT(DISTINCT users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "COUNT(DISTINCT users.name)",
+			},
 		},
 		{
 			name: "Ensure AS alias not in COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName.As("user_name")),
-			qs:   "COUNT(DISTINCT users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "COUNT(DISTINCT users.name)",
+			},
 		},
 		{
 			name: "CAST(column AS type)",
 			c:    Cast(colUserName, SQL_TYPE_TEXT),
-			qs:   "CAST(users.name AS TEXT)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CAST(users.name AS TEXT)",
+			},
 		},
 		{
 			name: "TRIM(column)",
 			c:    Trim(colUserName),
-			qs:   "TRIM(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "TRIM(users.name)",
+			},
 		},
 		{
 			name: "CHAR_LENGTH(column)",
 			c:    CharLength(colUserName),
-			qs:   "CHAR_LENGTH(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CHAR_LENGTH(users.name)",
+			},
 		},
 		{
 			name: "BIT_LENGTH(column)",
 			c:    BitLength(colUserName),
-			qs:   "BIT_LENGTH(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "BIT_LENGTH(users.name)",
+			},
 		},
 		{
 			name: "ASCII(column)",
 			c:    Ascii(colUserName),
-			qs:   "ASCII(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "ASCII(users.name)",
+			},
 		},
 		{
 			name: "REVERSE(column)",
 			c:    Reverse(colUserName),
-			qs:   "REVERSE(users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "REVERSE(users.name)",
+			},
 		},
 		{
 			name: "CONCAT(column, column)",
 			c:    Concat(colUserName, colUserName),
-			qs:   "CONCAT(users.name, users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CONCAT(users.name, users.name)",
+			},
 		},
 		{
-			name:  "CONCAT_WS(string, column, column)",
-			c:     ConcatWs("-", colUserName, colUserName),
-			qs:    "CONCAT_WS(?, users.name, users.name)",
+			name: "CONCAT_WS(string, column, column)",
+			c:    ConcatWs("-", colUserName, colUserName),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CONCAT_WS(?, users.name, users.name)",
+			},
 			qargs: []interface{}{"-"},
 		},
 		{
 			name: "NOW()",
 			c:    Now(),
-			qs:   "NOW()",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "NOW()",
+			},
 		},
 		{
 			name: "CURRENT_TIMESTAMP()",
 			c:    CurrentTimestamp(),
-			qs:   "CURRENT_TIMESTAMP()",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CURRENT_TIMESTAMP()",
+			},
 		},
 		{
 			name: "CURRENT_TIME()",
 			c:    CurrentTime(),
-			qs:   "CURRENT_TIME()",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CURRENT_TIME()",
+			},
 		},
 		{
 			name: "CURRENT_DATE()",
 			c:    CurrentDate(),
-			qs:   "CURRENT_DATE()",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "CURRENT_DATE()",
+			},
 		},
 		{
 			name: "EXTRACT(unit FROM column)",
 			c:    Extract(colUserName, UNIT_MINUTE_SECOND),
-			qs:   "EXTRACT(MINUTE_SECOND FROM users.name)",
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
+			},
 		},
 	}
 	for _, test := range tests {
@@ -131,16 +173,20 @@ func TestFunctions(t *testing.T) {
 		argc := test.c.argCount()
 		assert.Equal(expArgc, argc)
 
-		expLen := len(test.qs)
-		size := test.c.size()
-		size += interpolationLength(DIALECT_MYSQL, argc)
-		assert.Equal(expLen, size)
+		// Test the MySQL SQL dialect output
+		{
+			qs := test.qs[DIALECT_MYSQL]
+			expLen := len(qs)
+			size := test.c.size()
+			size += interpolationLength(DIALECT_MYSQL, argc)
+			assert.Equal(expLen, size)
 
-		b := make([]byte, size)
-		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+			b := make([]byte, size)
+			curArg := 0
+			written := test.c.scan(b, test.qargs, &curArg)
 
-		assert.Equal(written, size)
-		assert.Equal(test.qs, string(b))
+			assert.Equal(written, size)
+			assert.Equal(qs, string(b))
+		}
 	}
 }

--- a/function_test.go
+++ b/function_test.go
@@ -23,63 +23,72 @@ func TestFunctions(t *testing.T) {
 			name: "MAX(column)",
 			c:    Max(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "MAX(users.name)",
+				DIALECT_MYSQL:      "MAX(users.name)",
+				DIALECT_POSTGRESQL: "MAX(users.name)",
 			},
 		},
 		{
 			name: "aliased function",
 			c:    Max(colUserName).As("max_name"),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "MAX(users.name) AS max_name",
+				DIALECT_MYSQL:      "MAX(users.name) AS max_name",
+				DIALECT_POSTGRESQL: "MAX(users.name) AS max_name",
 			},
 		},
 		{
 			name: "MIN(column)",
 			c:    Min(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "MIN(users.name)",
+				DIALECT_MYSQL:      "MIN(users.name)",
+				DIALECT_POSTGRESQL: "MIN(users.name)",
 			},
 		},
 		{
 			name: "SUM(column)",
 			c:    Sum(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "SUM(users.name)",
+				DIALECT_MYSQL:      "SUM(users.name)",
+				DIALECT_POSTGRESQL: "SUM(users.name)",
 			},
 		},
 		{
 			name: "AVG(column)",
 			c:    Avg(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "AVG(users.name)",
+				DIALECT_MYSQL:      "AVG(users.name)",
+				DIALECT_POSTGRESQL: "AVG(users.name)",
 			},
 		},
 		{
 			name: "COUNT(*)",
 			c:    Count(users),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "COUNT(*)",
+				DIALECT_MYSQL:      "COUNT(*)",
+				DIALECT_POSTGRESQL: "COUNT(*)",
 			},
 		},
 		{
 			name: "COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "COUNT(DISTINCT users.name)",
+				DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
+				DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
 			},
 		},
 		{
 			name: "Ensure AS alias not in COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName.As("user_name")),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "COUNT(DISTINCT users.name)",
+				DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
+				DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
 			},
 		},
 		{
 			name: "CAST(column AS type)",
 			c:    Cast(colUserName, SQL_TYPE_TEXT),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CAST(users.name AS TEXT)",
+				DIALECT_MYSQL:      "CAST(users.name AS TEXT)",
+				DIALECT_POSTGRESQL: "CAST(users.name AS TEXT)",
 			},
 		},
 		{
@@ -87,41 +96,49 @@ func TestFunctions(t *testing.T) {
 			c:    Trim(colUserName),
 			qs: map[Dialect]string{
 				DIALECT_MYSQL: "TRIM(users.name)",
+				// Should be:
+				// DIALECT_POSTGRESQL: "BTRIM(users.name)",
+				DIALECT_POSTGRESQL: "TRIM(users.name)",
 			},
 		},
 		{
 			name: "CHAR_LENGTH(column)",
 			c:    CharLength(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CHAR_LENGTH(users.name)",
+				DIALECT_MYSQL:      "CHAR_LENGTH(users.name)",
+				DIALECT_POSTGRESQL: "CHAR_LENGTH(users.name)",
 			},
 		},
 		{
 			name: "BIT_LENGTH(column)",
 			c:    BitLength(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "BIT_LENGTH(users.name)",
+				DIALECT_MYSQL:      "BIT_LENGTH(users.name)",
+				DIALECT_POSTGRESQL: "BIT_LENGTH(users.name)",
 			},
 		},
 		{
 			name: "ASCII(column)",
 			c:    Ascii(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "ASCII(users.name)",
+				DIALECT_MYSQL:      "ASCII(users.name)",
+				DIALECT_POSTGRESQL: "ASCII(users.name)",
 			},
 		},
 		{
 			name: "REVERSE(column)",
 			c:    Reverse(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "REVERSE(users.name)",
+				DIALECT_MYSQL:      "REVERSE(users.name)",
+				DIALECT_POSTGRESQL: "REVERSE(users.name)",
 			},
 		},
 		{
 			name: "CONCAT(column, column)",
 			c:    Concat(colUserName, colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CONCAT(users.name, users.name)",
+				DIALECT_MYSQL:      "CONCAT(users.name, users.name)",
+				DIALECT_POSTGRESQL: "CONCAT(users.name, users.name)",
 			},
 		},
 		{
@@ -129,6 +146,8 @@ func TestFunctions(t *testing.T) {
 			c:    ConcatWs("-", colUserName, colUserName),
 			qs: map[Dialect]string{
 				DIALECT_MYSQL: "CONCAT_WS(?, users.name, users.name)",
+				// Should be:
+				// DIALECT_POSTGRESQL: "CONCAT_WS($1, users.name, users.name)",
 			},
 			qargs: []interface{}{"-"},
 		},
@@ -136,28 +155,32 @@ func TestFunctions(t *testing.T) {
 			name: "NOW()",
 			c:    Now(),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "NOW()",
+				DIALECT_MYSQL:      "NOW()",
+				DIALECT_POSTGRESQL: "NOW()",
 			},
 		},
 		{
 			name: "CURRENT_TIMESTAMP()",
 			c:    CurrentTimestamp(),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CURRENT_TIMESTAMP()",
+				DIALECT_MYSQL:      "CURRENT_TIMESTAMP()",
+				DIALECT_POSTGRESQL: "CURRENT_TIMESTAMP()",
 			},
 		},
 		{
 			name: "CURRENT_TIME()",
 			c:    CurrentTime(),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CURRENT_TIME()",
+				DIALECT_MYSQL:      "CURRENT_TIME()",
+				DIALECT_POSTGRESQL: "CURRENT_TIME()",
 			},
 		},
 		{
 			name: "CURRENT_DATE()",
 			c:    CurrentDate(),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CURRENT_DATE()",
+				DIALECT_MYSQL:      "CURRENT_DATE()",
+				DIALECT_POSTGRESQL: "CURRENT_DATE()",
 			},
 		},
 		{
@@ -165,6 +188,9 @@ func TestFunctions(t *testing.T) {
 			c:    Extract(colUserName, UNIT_MINUTE_SECOND),
 			qs: map[Dialect]string{
 				DIALECT_MYSQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
+				// Should be:
+				// DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM TIMESTAMP users.name)",
+				DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
 			},
 		},
 	}
@@ -173,12 +199,12 @@ func TestFunctions(t *testing.T) {
 		argc := test.c.argCount()
 		assert.Equal(expArgc, argc)
 
-		// Test the MySQL SQL dialect output
-		{
-			qs := test.qs[DIALECT_MYSQL]
+		// Test each SQL dialect output
+		for dialect, qs := range test.qs {
+			test.c.dialect = dialect
 			expLen := len(qs)
 			size := test.c.size()
-			size += interpolationLength(DIALECT_MYSQL, argc)
+			size += interpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)

--- a/group_by.go
+++ b/group_by.go
@@ -4,6 +4,14 @@ type groupByClause struct {
 	cols []projection
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (gb *groupByClause) setDialect(dialect Dialect) {
+	for _, c := range gb.cols {
+		c.(element).setDialect(dialect)
+	}
+}
+
 func (gb *groupByClause) argCount() int {
 	argc := 0
 	return argc

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,6 +11,9 @@ type element interface {
 	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
 	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
 	scan([]byte, []interface{}, *int) int
+	// Sets the element's SQL dialect and pushes the dialect down into any
+	// nested elements
+	setDialect(Dialect)
 }
 
 // A projection is something that produces a scalar value. A column, column
@@ -27,6 +30,9 @@ type projection interface {
 	// disables the outputting of the "AS alias" extended output. Returns a
 	// function that resets the outputting of the "AS alias" extended output
 	disableAliasScan() func()
+	// Sets the element's SQL dialect and pushes the dialect down into any
+	// nested elements
+	setDialect(Dialect)
 }
 
 // A selection is something that produces rows. A table, table definition,
@@ -37,6 +43,9 @@ type selection interface {
 	size() int
 	argCount() int
 	scan([]byte, []interface{}, *int) int
+	// Sets the element's SQL dialect and pushes the dialect down into any
+	// nested elements
+	setDialect(Dialect)
 }
 
 // A Query is a placeholder for something that can be asked for the SQL string

--- a/limit.go
+++ b/limit.go
@@ -6,6 +6,10 @@ type limitClause struct {
 	dialect Dialect
 }
 
+func (lc *limitClause) setDialect(dialect Dialect) {
+	lc.dialect = dialect
+}
+
 func (lc *limitClause) argCount() int {
 	if lc.offset == nil {
 		return 1

--- a/list.go
+++ b/list.go
@@ -6,6 +6,14 @@ type List struct {
 	elements []element
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (l *List) setDialect(dialect Dialect) {
+	for _, el := range l.elements {
+		el.setDialect(dialect)
+	}
+}
+
 func (l *List) argCount() int {
 	ac := 0
 	for _, el := range l.elements {

--- a/order_by.go
+++ b/order_by.go
@@ -5,6 +5,12 @@ type sortColumn struct {
 	desc bool
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (sc *sortColumn) setDialect(dialect Dialect) {
+	// TODO(jaypipes): Anything to do here?)
+}
+
 func (sc *sortColumn) argCount() int {
 	return sc.p.argCount()
 }
@@ -32,6 +38,14 @@ func (sc *sortColumn) scan(b []byte, args []interface{}, curArg *int) int {
 
 type orderByClause struct {
 	scols []*sortColumn
+}
+
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (ob *orderByClause) setDialect(dialect Dialect) {
+	for _, sc := range ob.scols {
+		sc.setDialect(dialect)
+	}
 }
 
 func (ob *orderByClause) argCount() int {

--- a/select_statement.go
+++ b/select_statement.go
@@ -11,6 +11,24 @@ type selectStatement struct {
 	dialect    Dialect
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (s *selectStatement) setDialect(dialect Dialect) {
+	s.dialect = dialect
+	if s.where != nil {
+		s.where.setDialect(dialect)
+	}
+	if s.groupBy != nil {
+		s.groupBy.setDialect(dialect)
+	}
+	if s.orderBy != nil {
+		s.orderBy.setDialect(dialect)
+	}
+	if s.limit != nil {
+		s.limit.setDialect(dialect)
+	}
+}
+
 func (s *selectStatement) argCount() int {
 	argc := 0
 	for _, p := range s.projs {

--- a/select_statement.go
+++ b/select_statement.go
@@ -1,6 +1,6 @@
 package sqlb
 
-type selectClause struct {
+type selectStatement struct {
 	projs      []projection
 	selections []selection
 	joins      []*joinClause
@@ -11,7 +11,7 @@ type selectClause struct {
 	dialect    Dialect
 }
 
-func (s *selectClause) argCount() int {
+func (s *selectStatement) argCount() int {
 	argc := 0
 	for _, p := range s.projs {
 		argc += p.argCount()
@@ -37,7 +37,7 @@ func (s *selectClause) argCount() int {
 	return argc
 }
 
-func (s *selectClause) size() int {
+func (s *selectStatement) size() int {
 	size := len(Symbols[SYM_SELECT])
 	nprojs := len(s.projs)
 	for _, p := range s.projs {
@@ -70,7 +70,7 @@ func (s *selectClause) size() int {
 	return size
 }
 
-func (s *selectClause) scan(b []byte, args []interface{}, curArg *int) int {
+func (s *selectStatement) scan(b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_SELECT])
 	nprojs := len(s.projs)
@@ -108,12 +108,12 @@ func (s *selectClause) scan(b []byte, args []interface{}, curArg *int) int {
 	return bw
 }
 
-func (s *selectClause) addJoin(jc *joinClause) *selectClause {
+func (s *selectStatement) addJoin(jc *joinClause) *selectStatement {
 	s.joins = append(s.joins, jc)
 	return s
 }
 
-func (s *selectClause) addWhere(e *Expression) *selectClause {
+func (s *selectStatement) addWhere(e *Expression) *selectStatement {
 	if s.where == nil {
 		s.where = &whereClause{filters: make([]*Expression, 0)}
 	}
@@ -122,8 +122,8 @@ func (s *selectClause) addWhere(e *Expression) *selectClause {
 }
 
 // Given one or more columns, either set or add to the GROUP BY clause for
-// the selectClause
-func (s *selectClause) addGroupBy(cols ...projection) *selectClause {
+// the selectStatement
+func (s *selectStatement) addGroupBy(cols ...projection) *selectStatement {
 	if len(cols) == 0 {
 		return s
 	}
@@ -145,8 +145,8 @@ func (s *selectClause) addGroupBy(cols ...projection) *selectClause {
 }
 
 // Given one or more sort columns, either set or add to the ORDER BY clause for
-// the selectClause
-func (s *selectClause) addOrderBy(sortCols ...*sortColumn) *selectClause {
+// the selectStatement
+func (s *selectStatement) addOrderBy(sortCols ...*sortColumn) *selectStatement {
 	if len(sortCols) == 0 {
 		return s
 	}
@@ -167,20 +167,20 @@ func (s *selectClause) addOrderBy(sortCols ...*sortColumn) *selectClause {
 	return s
 }
 
-func (s *selectClause) setLimitWithOffset(limit int, offset int) *selectClause {
+func (s *selectStatement) setLimitWithOffset(limit int, offset int) *selectStatement {
 	lc := &limitClause{limit: limit, dialect: s.dialect}
 	lc.offset = &offset
 	s.limit = lc
 	return s
 }
 
-func (s *selectClause) setLimit(limit int) *selectClause {
+func (s *selectStatement) setLimit(limit int) *selectStatement {
 	lc := &limitClause{limit: limit, dialect: s.dialect}
 	s.limit = lc
 	return s
 }
 
-func containsJoin(s *selectClause, j *joinClause) bool {
+func containsJoin(s *selectStatement, j *joinClause) bool {
 	for _, sj := range s.joins {
 		if j == sj {
 			return true
@@ -189,11 +189,11 @@ func containsJoin(s *selectClause, j *joinClause) bool {
 	return false
 }
 
-func addToProjections(s *selectClause, p projection) {
+func addToProjections(s *selectStatement, p projection) {
 	s.projs = append(s.projs, p)
 }
 
-func (s *selectClause) removeSelection(toRemove selection) {
+func (s *selectStatement) removeSelection(toRemove selection) {
 	idx := -1
 	for x, sel := range s.selections {
 		if sel == toRemove {

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -23,13 +23,13 @@ func TestSelectClause(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		c     *selectClause
+		s     *selectStatement
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "A literal value",
-			c: &selectClause{
+			s: &selectStatement{
 				projs: []projection{&value{val: 1}},
 			},
 			qs:    "SELECT ?",
@@ -37,7 +37,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "A literal value aliased",
-			c: &selectClause{
+			s: &selectStatement{
 				projs: []projection{
 					&value{alias: "foo", val: 1},
 				},
@@ -47,7 +47,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Two literal values",
-			c: &selectClause{
+			s: &selectStatement{
 				projs: []projection{
 					&value{val: 1},
 					&value{val: 1},
@@ -58,7 +58,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and column",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 			},
@@ -66,7 +66,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "aliased Table and Column",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users.As("u")},
 				projs: []projection{
 					users.As("u").C("name"),
@@ -76,7 +76,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and multiple Column",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserId, colUserName},
 			},
@@ -84,7 +84,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple WHERE",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 				where: &whereClause{
@@ -98,7 +98,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple LIMIT",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 				limit:      &limitClause{limit: 10},
@@ -108,7 +108,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple ORDER BY",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 				orderBy: &orderByClause{
@@ -119,7 +119,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple GROUP BY",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 				groupBy: &groupByClause{
@@ -130,7 +130,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "GROUP BY, ORDER BY and LIMIT",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{colUserName},
 				groupBy: &groupByClause{
@@ -146,7 +146,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Single JOIN",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{articles},
 				projs:      []projection{colArticleId, colUserName.As("author")},
 				joins: []*joinClause{
@@ -161,7 +161,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Multiple JOINs",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{articles},
 				projs:      []projection{colArticleId, colUserName.As("author"), colArticleStateName.As("state")},
 				joins: []*joinClause{
@@ -181,7 +181,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "COUNT(*) on a table",
-			c: &selectClause{
+			s: &selectStatement{
 				selections: []selection{users},
 				projs:      []projection{Count(users)},
 			},
@@ -190,17 +190,17 @@ func TestSelectClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.c.argCount()
+		argc := test.s.argCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size()
+		size := test.s.size()
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.s.scan(b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/string_functions.go
+++ b/string_functions.go
@@ -1,0 +1,93 @@
+package sqlb
+
+type trimFunc struct {
+	sel     selection
+	alias   string
+	subject element
+	dialect Dialect
+}
+
+// Sets the sqlFunc's dialect and pushes the dialect down into any of the
+// sqlFunc's elements
+func (f *trimFunc) setDialect(dialect Dialect) {
+	f.dialect = dialect
+	switch f.subject.(type) {
+	case *value:
+		v := f.subject.(*value)
+		v.dialect = dialect
+	}
+}
+
+func (f *trimFunc) from() selection {
+	return f.sel
+}
+
+func (f *trimFunc) disableAliasScan() func() {
+	origAlias := f.alias
+	f.alias = ""
+	return func() { f.alias = origAlias }
+}
+
+func (f *trimFunc) As(alias string) *trimFunc {
+	aliased := &trimFunc{
+		sel:     f.sel,
+		alias:   alias,
+		subject: f.subject,
+		dialect: f.dialect,
+	}
+	return aliased
+}
+
+func (f *trimFunc) argCount() int {
+	return f.subject.argCount()
+}
+
+func (f *trimFunc) size() int {
+	size := len(Symbols[SYM_TRIM]) + len(Symbols[SYM_RPAREN])
+	// We need to disable alias output for elements that are
+	// projections. We don't want to output, for example,
+	// "ON users.id AS user_id = articles.author"
+	switch f.subject.(type) {
+	case projection:
+		reset := f.subject.(projection).disableAliasScan()
+		defer reset()
+	}
+	size += f.subject.size()
+	if f.alias != "" {
+		size += len(Symbols[SYM_AS]) + len(f.alias)
+	}
+	return size
+}
+
+func (f *trimFunc) scan(b []byte, args []interface{}, curArg *int) int {
+	// TODO(jaypipes): Handle dialect differences
+	bw := copy(b, Symbols[SYM_TRIM])
+	// We need to disable alias output for elements that are
+	// projections. We don't want to output, for example,
+	// "ON users.id AS user_id = articles.author"
+	switch f.subject.(type) {
+	case projection:
+		reset := f.subject.(projection).disableAliasScan()
+		defer reset()
+	}
+	bw += f.subject.scan(b[bw:], args, curArg)
+	bw += copy(b[bw:], Symbols[SYM_RPAREN])
+	if f.alias != "" {
+		bw += copy(b[bw:], Symbols[SYM_AS])
+		bw += copy(b[bw:], f.alias)
+	}
+	return bw
+}
+
+func Trim(p projection) *trimFunc {
+	return &trimFunc{
+		subject: p.(element),
+		sel:     p.from(),
+	}
+}
+
+func (c *Column) Trim() *trimFunc {
+	f := Trim(c)
+	f.setDialect(c.tbl.meta.dialect)
+	return f
+}

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -1,0 +1,54 @@
+package sqlb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringFunctions(t *testing.T) {
+	assert := assert.New(t)
+
+	m := testFixtureMeta()
+	users := m.Table("users")
+	colUserName := users.C("name")
+
+	tests := []struct {
+		name  string
+		el    element
+		qs    map[Dialect]string
+		qargs []interface{}
+	}{
+		{
+			name: "TRIM(column)",
+			el:   Trim(colUserName),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL: "TRIM(users.name)",
+				// Should be:
+				// DIALECT_POSTGRESQL: "BTRIM(users.name)",
+				DIALECT_POSTGRESQL: "TRIM(users.name)",
+			},
+		},
+	}
+	for _, test := range tests {
+		expArgc := len(test.qargs)
+		argc := test.el.argCount()
+		assert.Equal(expArgc, argc)
+
+		// Test each SQL dialect output
+		for dialect, qs := range test.qs {
+			test.el.setDialect(dialect)
+			expLen := len(qs)
+			size := test.el.size()
+			size += interpolationLength(dialect, argc)
+			assert.Equal(expLen, size)
+
+			b := make([]byte, size)
+			curArg := 0
+			written := test.el.scan(b, test.qargs, &curArg)
+
+			assert.Equal(written, size)
+			assert.Equal(qs, string(b))
+		}
+	}
+}

--- a/table.go
+++ b/table.go
@@ -7,6 +7,14 @@ type Table struct {
 	columns []*Column
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (t *Table) setDialect(dialect Dialect) {
+	for _, c := range t.columns {
+		c.setDialect(dialect)
+	}
+}
+
 // Return a pointer to a Column with a name or alias matching the supplied
 // string, or nil if no such column is known
 func (t *Table) C(name string) *Column {

--- a/value.go
+++ b/value.go
@@ -11,6 +11,12 @@ type value struct {
 	dialect Dialect
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (v *value) setDialect(dialect Dialect) {
+	v.dialect = dialect
+}
+
 func (v *value) from() selection {
 	return v.sel
 }

--- a/where.go
+++ b/where.go
@@ -4,6 +4,14 @@ type whereClause struct {
 	filters []*Expression
 }
 
+// Sets the statement's dialect and pushes the dialect down into any of the
+// statement's sub-clauses
+func (w *whereClause) setDialect(dialect Dialect) {
+	for _, filter := range w.filters {
+		filter.setDialect(dialect)
+	}
+}
+
 func (w *whereClause) argCount() int {
 	argc := 0
 	for _, filter := range w.filters {


### PR DESCRIPTION
Another fairly major change to support SQL dialects. Adds a new setDialect() method to the element interface and begins the process of breaking out individual SQL functions into their own structs instead of using the scanTable strategy.

Issue #56 