### PR TITLE
Make Trim() good for PostgreSQL

### DIFF
--- a/string_functions.go
+++ b/string_functions.go
@@ -43,7 +43,14 @@ func (f *trimFunc) argCount() int {
 }
 
 func (f *trimFunc) size() int {
-	size := len(Symbols[SYM_TRIM]) + len(Symbols[SYM_RPAREN])
+	size := 0
+	switch f.dialect {
+	case DIALECT_POSTGRESQL:
+		size += len(Symbols[SYM_BTRIM])
+	default:
+		size += len(Symbols[SYM_TRIM])
+	}
+	size += len(Symbols[SYM_RPAREN])
 	// We need to disable alias output for elements that are
 	// projections. We don't want to output, for example,
 	// "ON users.id AS user_id = articles.author"
@@ -60,8 +67,13 @@ func (f *trimFunc) size() int {
 }
 
 func (f *trimFunc) scan(b []byte, args []interface{}, curArg *int) int {
-	// TODO(jaypipes): Handle dialect differences
-	bw := copy(b, Symbols[SYM_TRIM])
+	bw := 0
+	switch f.dialect {
+	case DIALECT_POSTGRESQL:
+		bw += copy(b[bw:], Symbols[SYM_BTRIM])
+	default:
+		bw += copy(b[bw:], Symbols[SYM_TRIM])
+	}
 	// We need to disable alias output for elements that are
 	// projections. We don't want to output, for example,
 	// "ON users.id AS user_id = articles.author"

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -23,10 +23,8 @@ func TestStringFunctions(t *testing.T) {
 			name: "TRIM(column)",
 			el:   Trim(colUserName),
 			qs: map[Dialect]string{
-				DIALECT_MYSQL: "TRIM(users.name)",
-				// Should be:
-				// DIALECT_POSTGRESQL: "BTRIM(users.name)",
-				DIALECT_POSTGRESQL: "TRIM(users.name)",
+				DIALECT_MYSQL:      "TRIM(users.name)",
+				DIALECT_POSTGRESQL: "BTRIM(users.name)",
 			},
 		},
 	}

--- a/symbol.go
+++ b/symbol.go
@@ -48,8 +48,7 @@ const (
 	SYM_COUNT_STAR
 	SYM_COUNT_DISTINCT
 	SYM_CAST
-	// TODO(jaypipes): Note that in PostreSQL, this is BTRIM(). We need a way
-	// to translate to DB dialects based on a driver.
+	SYM_BTRIM
 	SYM_TRIM
 	SYM_CHAR_LENGTH
 	SYM_BIT_LENGTH
@@ -212,6 +211,7 @@ var (
 		SYM_COUNT_STAR:              []byte("COUNT(*)"),
 		SYM_COUNT_DISTINCT:          []byte("COUNT(DISTINCT "),
 		SYM_CAST:                    []byte("CAST("),
+		SYM_BTRIM:                   []byte("BTRIM("),
 		SYM_TRIM:                    []byte("TRIM("),
 		SYM_CHAR_LENGTH:             []byte("CHAR_LENGTH("),
 		SYM_BIT_LENGTH:              []byte("BIT_LENGTH("),


### PR DESCRIPTION
Makes the sqlb.Trim() function output BTRIM() instead of TRIM() when
PostgreSQL is the SQL dialect.

Issue #56