### PR TITLE
Overhaul TRIM/BTRIM/LTRIM/RTRIM SQL function handling

### DIFF
--- a/string_functions.go
+++ b/string_functions.go
@@ -1,5 +1,40 @@
 package sqlb
 
+// TRIM/BTRIM/LTRIM/RTRIM SQL function support
+//
+// For MySQL, the TRIM() SQL function takes the following forms.
+//
+// Remove whitespace from before and after string:
+//		TRIM(string)
+// Remove whitespace from before string:
+//		LTRIM(string)
+// Remove whitespace from after string:
+//		RTRIM(string)
+// Remove the string remstr from before and after string:
+//		TRIM(remstr FROM string)
+// Remove the string remstr from before string:
+//		TRIM(LEADING remstr FROM string)
+// Remove the string remstr from after string:
+//		TRIM(TRAILING remstr FROM string)
+//
+// For PostgreSQL, the TRIM() SQL function takes the following forms.
+//
+// Remove whitespace from before and after string:
+//		BTRIM(string)
+// Remove whitespace from before string:
+//		TRIM(LEADING FROM string)
+// Remove whitespace from after string:
+//		TRIM(TRAILING FROM string)
+// Remove longest string containing any character in chars from before
+// and after string:
+//		TRIM(chars FROM string)
+// Remove longest string containing any character in chars from before
+// string:
+//		TRIM(LEADING chars FROM string)
+// Remove longest string containing any character in chars from after
+// string:
+//		TRIM(TRAILING chars FROM string)
+
 type TrimLocation int
 
 const (
@@ -40,10 +75,12 @@ func (f *trimFunc) disableAliasScan() func() {
 
 func (f *trimFunc) As(alias string) *trimFunc {
 	aliased := &trimFunc{
-		sel:     f.sel,
-		alias:   alias,
-		subject: f.subject,
-		dialect: f.dialect,
+		sel:      f.sel,
+		alias:    alias,
+		subject:  f.subject,
+		dialect:  f.dialect,
+		location: f.location,
+		chars:    f.chars,
 	}
 	return aliased
 }
@@ -52,13 +89,164 @@ func (f *trimFunc) argCount() int {
 	return f.subject.argCount()
 }
 
+// Helper function that returns the non-subject, non-interpolation size of the
+// TRIM() function for MySQL variants
+func trimFuncSizeMySQL(f *trimFunc) int {
+	size := 0
+	switch f.location {
+	case TRIM_LEADING:
+		if f.chars == nil {
+			// LTRIM(string)
+			size = len(Symbols[SYM_LTRIM])
+		} else {
+			// TRIM(LEADING remstr FROM string)
+			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_LEADING]) +
+				len(Symbols[SYM_FROM]) + 1)
+		}
+	case TRIM_TRAILING:
+		if f.chars == nil {
+			// LTRIM(string)
+			size = len(Symbols[SYM_RTRIM])
+		} else {
+			// TRIM(TRAILING remstr FROM string)
+			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_TRAILING]) +
+				len(Symbols[SYM_FROM]) + 1)
+		}
+	case TRIM_BOTH:
+		if f.chars == nil {
+			// TRIM(string)
+			size = len(Symbols[SYM_TRIM])
+		} else {
+			// TRIM(remstr FROM string)
+			size = len(Symbols[SYM_TRIM]) + len(Symbols[SYM_FROM]) + 1
+		}
+	}
+	return size
+}
+
+// Helper function that scans into the supplied SQL []byte buffer for the
+// TRIM/BTRIM() SQL function for MySQL
+// TRIM() function for MySQL variants
+func trimFuncScanMySQL(f *trimFunc, b []byte, args []interface{}, curArg *int) int {
+	bw := 0
+	switch f.location {
+	case TRIM_LEADING:
+		if f.chars == nil {
+			bw += copy(b[bw:], Symbols[SYM_LTRIM])
+		} else {
+			bw += copy(b[bw:], Symbols[SYM_TRIM])
+			bw += copy(b[bw:], Symbols[SYM_LEADING])
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], Symbols[SYM_FROM])
+		}
+	case TRIM_TRAILING:
+		if f.chars == nil {
+			bw += copy(b[bw:], Symbols[SYM_RTRIM])
+		} else {
+			bw += copy(b[bw:], Symbols[SYM_TRIM])
+			bw += copy(b[bw:], Symbols[SYM_TRAILING])
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], Symbols[SYM_FROM])
+		}
+	case TRIM_BOTH:
+		if f.chars == nil {
+			bw += copy(b[bw:], Symbols[SYM_TRIM])
+		} else {
+			bw += copy(b[bw:], Symbols[SYM_TRIM])
+			bw += copy(b[bw:], Symbols[SYM_BOTH])
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], Symbols[SYM_FROM])
+		}
+	}
+	return bw
+}
+
+// Helper function that returns the non-subject, non-interpolation size of the
+// TRIM() function for PostgreSQL variants
+func trimFuncSizePostgreSQL(f *trimFunc) int {
+	size := 0
+	switch f.location {
+	case TRIM_LEADING:
+		// TRIM(LEADING FROM string)
+		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_LEADING]) +
+			len(Symbols[SYM_FROM]))
+		if f.chars != nil {
+			// TRIM(LEADING chars FROM string)
+			size += 1
+		}
+	case TRIM_TRAILING:
+		// TRIM(TRAILING FROM string)
+		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_TRAILING]) +
+			len(Symbols[SYM_FROM]))
+		if f.chars != nil {
+			// TRIM(TRAILING chars FROM string)
+			size += 1
+		}
+	case TRIM_BOTH:
+		if f.chars == nil {
+			// BTRIM(string)
+			size = len(Symbols[SYM_BTRIM])
+		} else {
+			// TRIM(BOTH chars FROM string)
+			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_BOTH]) +
+				len(Symbols[SYM_FROM]) + 1)
+		}
+	}
+	return size
+}
+
+// Helper function that scans into the supplied SQL []byte buffer for the
+// TRIM/BTRIM() SQL function for PostgreSQL
+// TRIM() function for PostgreSQL variants
+func trimFuncScanPostgreSQL(f *trimFunc, b []byte, args []interface{}, curArg *int) int {
+	bw := 0
+	switch f.location {
+	case TRIM_LEADING:
+		bw += copy(b[bw:], Symbols[SYM_TRIM])
+		bw += copy(b[bw:], Symbols[SYM_LEADING])
+		if f.chars != nil {
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+		}
+		bw += copy(b[bw:], Symbols[SYM_FROM])
+	case TRIM_TRAILING:
+		bw += copy(b[bw:], Symbols[SYM_TRIM])
+		bw += copy(b[bw:], Symbols[SYM_TRAILING])
+		if f.chars != nil {
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+		}
+		bw += copy(b[bw:], Symbols[SYM_FROM])
+	case TRIM_BOTH:
+		if f.chars == nil {
+			bw += copy(b[bw:], Symbols[SYM_BTRIM])
+		} else {
+			bw += copy(b[bw:], Symbols[SYM_TRIM])
+			bw += copy(b[bw:], Symbols[SYM_BOTH])
+			args[*curArg] = string(f.chars)
+			*curArg++
+			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], Symbols[SYM_FROM])
+		}
+	}
+	return bw
+}
+
 func (f *trimFunc) size() int {
 	size := 0
 	switch f.dialect {
 	case DIALECT_POSTGRESQL:
-		size += len(Symbols[SYM_BTRIM])
+		size = trimFuncSizePostgreSQL(f)
 	default:
-		size += len(Symbols[SYM_TRIM])
+		size = trimFuncSizeMySQL(f)
 	}
 	size += len(Symbols[SYM_RPAREN])
 	// We need to disable alias output for elements that are
@@ -80,9 +268,9 @@ func (f *trimFunc) scan(b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	switch f.dialect {
 	case DIALECT_POSTGRESQL:
-		bw += copy(b[bw:], Symbols[SYM_BTRIM])
+		bw += trimFuncScanPostgreSQL(f, b[bw:], args, curArg)
 	default:
-		bw += copy(b[bw:], Symbols[SYM_TRIM])
+		bw += trimFuncScanMySQL(f, b[bw:], args, curArg)
 	}
 	// We need to disable alias output for elements that are
 	// projections. We don't want to output, for example,
@@ -113,6 +301,40 @@ func Trim(p projection) *trimFunc {
 
 func (c *Column) Trim() *trimFunc {
 	f := Trim(c)
+	f.setDialect(c.tbl.meta.dialect)
+	return f
+}
+
+// Returns a struct that will output the LTRIM() SQL function for MySQL and the
+// TRIM(LEADING FROM column) SQL function for PostgreSQL. The SQL function in
+// either case will remove whitespace from the start of the supplied projection
+func LTrim(p projection) *trimFunc {
+	return &trimFunc{
+		subject:  p.(element),
+		sel:      p.from(),
+		location: TRIM_LEADING,
+	}
+}
+
+func (c *Column) LTrim() *trimFunc {
+	f := LTrim(c)
+	f.setDialect(c.tbl.meta.dialect)
+	return f
+}
+
+// Returns a struct that will output the RTRIM() SQL function for MySQL and the
+// TRIM(TRAILING FROM column) SQL function for PostgreSQL. The SQL function in
+// either case will remove whitespace from the start of the supplied projection
+func RTrim(p projection) *trimFunc {
+	return &trimFunc{
+		subject:  p.(element),
+		sel:      p.from(),
+		location: TRIM_TRAILING,
+	}
+}
+
+func (c *Column) RTrim() *trimFunc {
+	f := LTrim(c)
 	f.setDialect(c.tbl.meta.dialect)
 	return f
 }

--- a/string_functions.go
+++ b/string_functions.go
@@ -1,14 +1,24 @@
 package sqlb
 
+type TrimLocation int
+
+const (
+	TRIM_BOTH TrimLocation = iota
+	TRIM_TRAILING
+	TRIM_LEADING
+)
+
 type trimFunc struct {
-	sel     selection
-	alias   string
-	subject element
-	dialect Dialect
+	sel      selection
+	alias    string
+	subject  element
+	dialect  Dialect
+	chars    []byte
+	location TrimLocation
 }
 
-// Sets the sqlFunc's dialect and pushes the dialect down into any of the
-// sqlFunc's elements
+// Sets the element's dialect and pushes the dialect down into any of the
+// sub-elements
 func (f *trimFunc) setDialect(dialect Dialect) {
 	f.dialect = dialect
 	switch f.subject.(type) {
@@ -91,10 +101,13 @@ func (f *trimFunc) scan(b []byte, args []interface{}, curArg *int) int {
 	return bw
 }
 
+// Returns a struct that will output the TRIM() SQL function, trimming leading
+// and trailing whitespace from the supplied projection
 func Trim(p projection) *trimFunc {
 	return &trimFunc{
-		subject: p.(element),
-		sel:     p.from(),
+		subject:  p.(element),
+		sel:      p.from(),
+		location: TRIM_BOTH,
 	}
 }
 

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStringFunctions(t *testing.T) {
+func TestTrimFunctions(t *testing.T) {
 	assert := assert.New(t)
 
 	m := testFixtureMeta()
@@ -20,11 +20,27 @@ func TestStringFunctions(t *testing.T) {
 		qargs []interface{}
 	}{
 		{
-			name: "TRIM(column)",
+			name: "TRIM(column) or BTRIM(column)",
 			el:   Trim(colUserName),
 			qs: map[Dialect]string{
 				DIALECT_MYSQL:      "TRIM(users.name)",
 				DIALECT_POSTGRESQL: "BTRIM(users.name)",
+			},
+		},
+		{
+			name: "LTRIM(column) or TRIM(LEADING FROM column)",
+			el:   LTrim(colUserName),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL:      "LTRIM(users.name)",
+				DIALECT_POSTGRESQL: "TRIM(LEADING FROM users.name)",
+			},
+		},
+		{
+			name: "RTRIM(column) or TRIM(TRAILING FROM column)",
+			el:   RTrim(colUserName),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL:      "RTRIM(users.name)",
+				DIALECT_POSTGRESQL: "TRIM(TRAILING FROM users.name)",
 			},
 		},
 	}

--- a/symbol.go
+++ b/symbol.go
@@ -50,6 +50,11 @@ const (
 	SYM_CAST
 	SYM_BTRIM
 	SYM_TRIM
+	SYM_LTRIM
+	SYM_RTRIM
+	SYM_LEADING
+	SYM_TRAILING
+	SYM_BOTH
 	SYM_CHAR_LENGTH
 	SYM_BIT_LENGTH
 	SYM_ASCII
@@ -213,6 +218,11 @@ var (
 		SYM_CAST:                    []byte("CAST("),
 		SYM_BTRIM:                   []byte("BTRIM("),
 		SYM_TRIM:                    []byte("TRIM("),
+		SYM_LTRIM:                   []byte("LTRIM("),
+		SYM_RTRIM:                   []byte("RTRIM("),
+		SYM_LEADING:                 []byte("LEADING"),
+		SYM_TRAILING:                []byte("TRAILING"),
+		SYM_BOTH:                    []byte("BOTH"),
 		SYM_CHAR_LENGTH:             []byte("CHAR_LENGTH("),
 		SYM_BIT_LENGTH:              []byte("BIT_LENGTH("),
 		SYM_ASCII:                   []byte("ASCII("),


### PR DESCRIPTION
There are a bunch of variants of the TRIM() SQL function in MySQL and PostgreSQL. This patch adds support for many of those variants.

```
// For MySQL, the TRIM() SQL function takes the following forms.
//
// Remove whitespace from before and after string:
//             TRIM(string)
// Remove whitespace from before string:
//             LTRIM(string)
// Remove whitespace from after string:
//             RTRIM(string)
// Remove the string remstr from before and after string:
//             TRIM(remstr FROM string)
// Remove the string remstr from before string:
//             TRIM(LEADING remstr FROM string)
// Remove the string remstr from after string:
//             TRIM(TRAILING remstr FROM string)
//
// For PostgreSQL, the TRIM() SQL function takes the following forms.
//
// Remove whitespace from before and after string:
//             BTRIM(string)
// Remove whitespace from before string:
//             TRIM(LEADING FROM string)
// Remove whitespace from after string:
//             TRIM(TRAILING FROM string)
// Remove longest string containing any character in chars from before
// and after string:
//             TRIM(chars FROM string)
// Remove longest string containing any character in chars from before
// string:
//             TRIM(LEADING chars FROM string)
// Remove longest string containing any character in chars from after
// string:
//             TRIM(TRAILING chars FROM string)
```

Issue #56