### PR TITLE
TrimChars(), LTrimChars(), and RTrimChars() support

### DIFF
--- a/string_functions.go
+++ b/string_functions.go
@@ -27,7 +27,7 @@ package sqlb
 //		TRIM(TRAILING FROM string)
 // Remove longest string containing any character in chars from before
 // and after string:
-//		TRIM(chars FROM string)
+//		BTRIM(string, chars)
 // Remove longest string containing any character in chars from before
 // string:
 //		TRIM(LEADING chars FROM string)
@@ -48,7 +48,7 @@ type trimFunc struct {
 	alias    string
 	subject  element
 	dialect  Dialect
-	chars    []byte
+	chars    string
 	location TrimLocation
 }
 
@@ -86,7 +86,11 @@ func (f *trimFunc) As(alias string) *trimFunc {
 }
 
 func (f *trimFunc) argCount() int {
-	return f.subject.argCount()
+	argc := f.subject.argCount()
+	if f.chars != "" {
+		argc++
+	}
+	return argc
 }
 
 // Helper function that returns the non-subject, non-interpolation size of the
@@ -95,7 +99,7 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 	size := 0
 	switch f.location {
 	case TRIM_LEADING:
-		if f.chars == nil {
+		if f.chars == "" {
 			// LTRIM(string)
 			size = len(Symbols[SYM_LTRIM])
 		} else {
@@ -104,7 +108,7 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 				len(Symbols[SYM_FROM]) + 1)
 		}
 	case TRIM_TRAILING:
-		if f.chars == nil {
+		if f.chars == "" {
 			// LTRIM(string)
 			size = len(Symbols[SYM_RTRIM])
 		} else {
@@ -113,12 +117,12 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 				len(Symbols[SYM_FROM]) + 1)
 		}
 	case TRIM_BOTH:
-		if f.chars == nil {
+		if f.chars == "" {
 			// TRIM(string)
 			size = len(Symbols[SYM_TRIM])
 		} else {
 			// TRIM(remstr FROM string)
-			size = len(Symbols[SYM_TRIM]) + len(Symbols[SYM_FROM]) + 1
+			size = len(Symbols[SYM_TRIM]) + len(Symbols[SYM_FROM])
 		}
 	}
 	return size
@@ -131,38 +135,40 @@ func trimFuncScanMySQL(f *trimFunc, b []byte, args []interface{}, curArg *int) i
 	bw := 0
 	switch f.location {
 	case TRIM_LEADING:
-		if f.chars == nil {
+		if f.chars == "" {
 			bw += copy(b[bw:], Symbols[SYM_LTRIM])
 		} else {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
 			bw += copy(b[bw:], Symbols[SYM_LEADING])
-			args[*curArg] = string(f.chars)
+			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], []byte{' '})
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
 	case TRIM_TRAILING:
-		if f.chars == nil {
+		if f.chars == "" {
 			bw += copy(b[bw:], Symbols[SYM_RTRIM])
 		} else {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
 			bw += copy(b[bw:], Symbols[SYM_TRAILING])
-			args[*curArg] = string(f.chars)
+			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], []byte{' '})
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
 	case TRIM_BOTH:
-		if f.chars == nil {
+		if f.chars == "" {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
 		} else {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
-			bw += copy(b[bw:], Symbols[SYM_BOTH])
-			args[*curArg] = string(f.chars)
+			bw += scanInterpolationMarker(f.dialect, b[bw:], *curArg)
+			args[*curArg] = f.chars
 			*curArg++
-			bw += copy(b[bw:], []byte{' '})
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
 	}
 	return bw
 }
@@ -176,7 +182,7 @@ func trimFuncSizePostgreSQL(f *trimFunc) int {
 		// TRIM(LEADING FROM string)
 		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_LEADING]) +
 			len(Symbols[SYM_FROM]))
-		if f.chars != nil {
+		if f.chars != "" {
 			// TRIM(LEADING chars FROM string)
 			size += 1
 		}
@@ -184,18 +190,17 @@ func trimFuncSizePostgreSQL(f *trimFunc) int {
 		// TRIM(TRAILING FROM string)
 		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_TRAILING]) +
 			len(Symbols[SYM_FROM]))
-		if f.chars != nil {
+		if f.chars != "" {
 			// TRIM(TRAILING chars FROM string)
 			size += 1
 		}
 	case TRIM_BOTH:
-		if f.chars == nil {
+		if f.chars == "" {
 			// BTRIM(string)
 			size = len(Symbols[SYM_BTRIM])
 		} else {
-			// TRIM(BOTH chars FROM string)
-			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_BOTH]) +
-				len(Symbols[SYM_FROM]) + 1)
+			// BTRIM(string, chars)
+			size = len(Symbols[SYM_BTRIM]) + len(Symbols[SYM_COMMA_WS])
 		}
 	}
 	return size
@@ -210,34 +215,47 @@ func trimFuncScanPostgreSQL(f *trimFunc, b []byte, args []interface{}, curArg *i
 	case TRIM_LEADING:
 		bw += copy(b[bw:], Symbols[SYM_TRIM])
 		bw += copy(b[bw:], Symbols[SYM_LEADING])
-		if f.chars != nil {
-			args[*curArg] = string(f.chars)
+		if f.chars != "" {
+			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], []byte{' '})
 		}
 		bw += copy(b[bw:], Symbols[SYM_FROM])
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
 	case TRIM_TRAILING:
 		bw += copy(b[bw:], Symbols[SYM_TRIM])
 		bw += copy(b[bw:], Symbols[SYM_TRAILING])
-		if f.chars != nil {
-			args[*curArg] = string(f.chars)
+		if f.chars != "" {
+			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], []byte{' '})
 		}
 		bw += copy(b[bw:], Symbols[SYM_FROM])
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
 	case TRIM_BOTH:
-		if f.chars == nil {
-			bw += copy(b[bw:], Symbols[SYM_BTRIM])
-		} else {
-			bw += copy(b[bw:], Symbols[SYM_TRIM])
-			bw += copy(b[bw:], Symbols[SYM_BOTH])
-			args[*curArg] = string(f.chars)
+		bw += copy(b[bw:], Symbols[SYM_BTRIM])
+		bw += trimFuncScanSubject(f, b[bw:], args, curArg)
+		if f.chars != "" {
+			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
+			bw += scanInterpolationMarker(f.dialect, b[bw:], *curArg)
+			args[*curArg] = f.chars
 			*curArg++
-			bw += copy(b[bw:], []byte{' '})
-			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
 	}
 	return bw
+}
+
+// Scan in the subject of the TRIM() function
+func trimFuncScanSubject(f *trimFunc, b []byte, args []interface{}, curArg *int) int {
+	// We need to disable alias output for elements that are
+	// projections. We don't want to output, for example,
+	// "ON users.id AS user_id = TRIM(articles.author)"
+	switch f.subject.(type) {
+	case projection:
+		reset := f.subject.(projection).disableAliasScan()
+		defer reset()
+	}
+	return f.subject.scan(b, args, curArg)
 }
 
 func (f *trimFunc) size() int {
@@ -251,7 +269,7 @@ func (f *trimFunc) size() int {
 	size += len(Symbols[SYM_RPAREN])
 	// We need to disable alias output for elements that are
 	// projections. We don't want to output, for example,
-	// "ON users.id AS user_id = articles.author"
+	// "ON users.id AS user_id = TRIM(articles.author)"
 	switch f.subject.(type) {
 	case projection:
 		reset := f.subject.(projection).disableAliasScan()
@@ -272,15 +290,6 @@ func (f *trimFunc) scan(b []byte, args []interface{}, curArg *int) int {
 	default:
 		bw += trimFuncScanMySQL(f, b[bw:], args, curArg)
 	}
-	// We need to disable alias output for elements that are
-	// projections. We don't want to output, for example,
-	// "ON users.id AS user_id = articles.author"
-	switch f.subject.(type) {
-	case projection:
-		reset := f.subject.(projection).disableAliasScan()
-		defer reset()
-	}
-	bw += f.subject.scan(b[bw:], args, curArg)
 	bw += copy(b[bw:], Symbols[SYM_RPAREN])
 	if f.alias != "" {
 		bw += copy(b[bw:], Symbols[SYM_AS])
@@ -335,6 +344,23 @@ func RTrim(p projection) *trimFunc {
 
 func (c *Column) RTrim() *trimFunc {
 	f := LTrim(c)
+	f.setDialect(c.tbl.meta.dialect)
+	return f
+}
+
+// Returns a struct that will output the TRIM() SQL function, trimming leading
+// and trailing whitespace from the supplied projection
+func TrimChars(p projection, chars string) *trimFunc {
+	return &trimFunc{
+		subject:  p.(element),
+		sel:      p.from(),
+		location: TRIM_BOTH,
+		chars:    chars,
+	}
+}
+
+func (c *Column) TrimChars(chars string) *trimFunc {
+	f := TrimChars(c, chars)
 	f.setDialect(c.tbl.meta.dialect)
 	return f
 }

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -52,6 +52,24 @@ func TestTrimFunctions(t *testing.T) {
 			},
 			qargs: []interface{}{"xyz"},
 		},
+		{
+			name: "TRIM(LEADING remstr FROM column)",
+			el:   LTrimChars(colUserName, "xyz"),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL:      "TRIM(LEADING ? FROM users.name)",
+				DIALECT_POSTGRESQL: "TRIM(LEADING $1 FROM users.name)",
+			},
+			qargs: []interface{}{"xyz"},
+		},
+		{
+			name: "TRIM(TRAILING remstr FROM column)",
+			el:   RTrimChars(colUserName, "xyz"),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL:      "TRIM(TRAILING ? FROM users.name)",
+				DIALECT_POSTGRESQL: "TRIM(TRAILING $1 FROM users.name)",
+			},
+			qargs: []interface{}{"xyz"},
+		},
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -43,6 +43,15 @@ func TestTrimFunctions(t *testing.T) {
 				DIALECT_POSTGRESQL: "TRIM(TRAILING FROM users.name)",
 			},
 		},
+		{
+			name: "TRIM(remstr FROM column) OR BTRIM(column, chars)",
+			el:   TrimChars(colUserName, "xyz"),
+			qs: map[Dialect]string{
+				DIALECT_MYSQL:      "TRIM(? FROM users.name)",
+				DIALECT_POSTGRESQL: "BTRIM(users.name, $1)",
+			},
+			qargs: []interface{}{"xyz"},
+		},
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
@@ -58,11 +67,15 @@ func TestTrimFunctions(t *testing.T) {
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
+			args := make([]interface{}, argc)
 			curArg := 0
-			written := test.el.scan(b, test.qargs, &curArg)
+			written := test.el.scan(b, args, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))
+			if expArgc > 0 {
+				assert.Equal(args, test.qargs)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds support for the following SQL function formats in MySQL and PostgreSQL:

```
TRIM(chars FROM column) | BTRIM(columns, chars)
TRIM(LEADING chars FROM column)
TRIM(TRAILING chars FROM column
```

Using the new `sqlb.TrimChars()`, `sqlb.LTrimChars()` and `sqlb.RTrimChars()` functions.

Issue #56