### PR TITLE
Initial pretty print support

### DIFF
--- a/column.go
+++ b/column.go
@@ -1,16 +1,9 @@
 package sqlb
 
 type Column struct {
-	alias   string
-	name    string
-	tbl     *Table
-	dialect Dialect
-}
-
-// Sets the statement's dialect and pushes the dialect down into any of the
-// statement's sub-clauses
-func (c *Column) setDialect(dialect Dialect) {
-	c.dialect = dialect
+	alias string
+	name  string
+	tbl   *Table
 }
 
 func (c *Column) from() selection {
@@ -31,7 +24,7 @@ func (c *Column) argCount() int {
 	return 0
 }
 
-func (c *Column) size() int {
+func (c *Column) size(scanner *sqlScanner) int {
 	size := 0
 	if c.tbl.alias != "" {
 		size += len(c.tbl.alias)
@@ -46,7 +39,7 @@ func (c *Column) size() int {
 	return size
 }
 
-func (c *Column) scan(b []byte, args []interface{}, curArg *int) int {
+func (c *Column) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if c.tbl.alias != "" {
 		bw += copy(b[bw:], c.tbl.alias)

--- a/column_test.go
+++ b/column_test.go
@@ -14,11 +14,11 @@ func TestC(t *testing.T) {
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := c.size()
+	s := c.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(b, nil, nil)
+	written := c.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -32,11 +32,11 @@ func TestColumnWithTableAlias(t *testing.T) {
 
 	exp := "u.name"
 	expLen := len(exp)
-	s := c.size()
+	s := c.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(b, nil, nil)
+	written := c.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -50,11 +50,11 @@ func TestColumnAlias(t *testing.T) {
 
 	exp := "users.name AS user_name"
 	expLen := len(exp)
-	s := c.size()
+	s := c.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(b, nil, nil)
+	written := c.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/delete.go
+++ b/delete.go
@@ -25,28 +25,24 @@ func (q *DeleteQuery) Error() error {
 }
 
 func (q *DeleteQuery) String() string {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *DeleteQuery) StringArgs() (string, []interface{}) {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -7,6 +7,8 @@ type deleteStatement struct {
 	where *whereClause
 }
 
+func (s *deleteStatement) setDialect(dialect Dialect) {}
+
 func (s *deleteStatement) argCount() int {
 	argc := 0
 	if s.where != nil {

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -7,8 +7,6 @@ type deleteStatement struct {
 	where *whereClause
 }
 
-func (s *deleteStatement) setDialect(dialect Dialect) {}
-
 func (s *deleteStatement) argCount() int {
 	argc := 0
 	if s.where != nil {
@@ -17,21 +15,21 @@ func (s *deleteStatement) argCount() int {
 	return argc
 }
 
-func (s *deleteStatement) size() int {
+func (s *deleteStatement) size(scanner *sqlScanner) int {
 	size := len(Symbols[SYM_DELETE]) + len(s.table.name)
 	if s.where != nil {
-		size += s.where.size()
+		size += s.where.size(scanner)
 	}
 	return size
 }
 
-func (s *deleteStatement) scan(b []byte, args []interface{}, curArg *int) int {
+func (s *deleteStatement) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_DELETE])
 	// We don't add any table alias when outputting the table identifier
 	bw += copy(b[bw:], s.table.name)
 	if s.where != nil {
-		bw += s.where.scan(b[bw:], args, curArg)
+		bw += s.where.scan(scanner, b[bw:], args, curArg)
 	}
 	return bw
 }

--- a/delete_statement_test.go
+++ b/delete_statement_test.go
@@ -46,13 +46,13 @@ func TestDeleteStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size()
+		size := test.s.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(b, test.qargs, &curArg)
+		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/derived.go
+++ b/derived.go
@@ -126,19 +126,6 @@ func (dc *derivedColumn) from() selection {
 	return dc.dt
 }
 
-func (dc *derivedColumn) projectionId() uint64 {
-	args := make([]string, 2)
-	args[0] = dc.dt.alias
-	if dc.alias != "" {
-		args[1] = dc.alias
-	} else if dc.c.alias != "" {
-		args[1] = dc.c.alias
-	} else {
-		args[1] = dc.c.name
-	}
-	return toId(args...)
-}
-
 func (dc *derivedColumn) disableAliasScan() func() {
 	origAlias := dc.alias
 	dc.alias = ""

--- a/derived_test.go
+++ b/derived_test.go
@@ -38,7 +38,7 @@ func TestDerived(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size()
+		s := test.c.size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -46,7 +46,7 @@ func TestDerived(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/expression.go
+++ b/expression.go
@@ -63,16 +63,6 @@ var (
 type Expression struct {
 	scanInfo scanInfo
 	elements []element
-	dialect  Dialect
-}
-
-// Sets the Expression's dialect and pushes the dialect down into any of the
-// Expression's elements
-func (e *Expression) setDialect(dialect Dialect) {
-	e.dialect = dialect
-	for _, el := range e.elements {
-		el.setDialect(dialect)
-	}
 }
 
 func (e *Expression) referrents() []selection {
@@ -95,7 +85,7 @@ func (e *Expression) argCount() int {
 	return ac
 }
 
-func (e *Expression) size() int {
+func (e *Expression) size(scanner *sqlScanner) int {
 	size := 0
 	elidx := 0
 	for _, sym := range e.scanInfo {
@@ -110,7 +100,7 @@ func (e *Expression) size() int {
 				defer reset()
 			}
 			elidx++
-			size += el.size()
+			size += el.size(scanner)
 		} else {
 			size += len(Symbols[sym])
 		}
@@ -118,7 +108,7 @@ func (e *Expression) size() int {
 	return size
 }
 
-func (e *Expression) scan(b []byte, args []interface{}, curArg *int) int {
+func (e *Expression) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	elidx := 0
 	for _, sym := range e.scanInfo {
@@ -133,7 +123,7 @@ func (e *Expression) scan(b []byte, args []interface{}, curArg *int) int {
 				defer reset()
 			}
 			elidx++
-			bw += el.scan(b[bw:], args, curArg)
+			bw += el.scan(scanner, b[bw:], args, curArg)
 		} else {
 			bw += copy(b[bw:], Symbols[sym])
 		}

--- a/expression_test.go
+++ b/expression_test.go
@@ -123,13 +123,13 @@ func TestExpressions(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size()
+		size := test.c.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/format.go
+++ b/format.go
@@ -15,7 +15,13 @@ type sqlScanner struct {
 	format  *FormatOptions
 }
 
-func (w *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable) {
+func (s *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable) {
 	curArg := 0
 	scannables[0].scan(b, args, &curArg)
+}
+
+// Returns the length (in bytes) of the interpolation markers, which depends on
+// the dialect in use when constructing the SQL buffer
+func (s *sqlScanner) interpolationLength(argc int) int {
+	return interpolationLength(s.dialect, argc)
 }

--- a/format.go
+++ b/format.go
@@ -1,0 +1,21 @@
+package sqlb
+
+type FormatOptions struct {
+	SeparateClauseWith string
+}
+
+var defaultFormatOptions = &FormatOptions{
+	SeparateClauseWith: " ",
+}
+
+// The struct that holds information about the formatting and dialect of the
+// output SQL that sqlb writes to the output buffer
+type sqlScanner struct {
+	dialect Dialect
+	format  *FormatOptions
+}
+
+func (w *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable) {
+	curArg := 0
+	scannables[0].scan(b, args, &curArg)
+}

--- a/format.go
+++ b/format.go
@@ -26,7 +26,10 @@ type sqlScanner struct {
 
 func (s *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable) {
 	curArg := 0
-	scannables[0].scan(b, args, &curArg)
+
+	for _, scannable := range scannables {
+		scannable.scan(b, args, &curArg)
+	}
 }
 
 func (s *sqlScanner) size(elements ...element) *ElementSizes {

--- a/format.go
+++ b/format.go
@@ -8,6 +8,11 @@ var defaultFormatOptions = &FormatOptions{
 	SeparateClauseWith: " ",
 }
 
+var defaultScanner = &sqlScanner{
+	dialect: DIALECT_MYSQL,
+	format:  defaultFormatOptions,
+}
+
 type ElementSizes struct {
 	// The number of interface{} arguments that the element will add to the
 	// slice of interface{} arguments that will eventually be constructed for
@@ -28,7 +33,7 @@ func (s *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable)
 	curArg := 0
 
 	for _, scannable := range scannables {
-		scannable.scan(b, args, &curArg)
+		scannable.scan(s, b, args, &curArg)
 	}
 }
 
@@ -38,7 +43,7 @@ func (s *sqlScanner) size(elements ...element) *ElementSizes {
 
 	for _, el := range elements {
 		argc += el.argCount()
-		buflen += el.size()
+		buflen += el.size(s)
 	}
 	buflen += interpolationLength(s.dialect, argc)
 

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,67 @@
+package sqlb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	m := testFixtureMeta()
+	users := m.Table("users")
+	colUserName := users.C("name")
+
+	tests := []struct {
+		name    string
+		scanner *sqlScanner
+		s       *selectStatement
+		qs      string
+		qargs   []interface{}
+	}{
+		{
+			name: "SELECT FROM with default space clause separator",
+			s: &selectStatement{
+				selections: []selection{users},
+				projs:      []projection{colUserName},
+			},
+			qs: "SELECT users.name FROM users",
+		},
+		{
+			name: "SELECT FROM with newline clause separator ",
+			s: &selectStatement{
+				selections: []selection{users},
+				projs:      []projection{colUserName},
+			},
+			scanner: &sqlScanner{
+				dialect: DIALECT_MYSQL,
+				format: &FormatOptions{
+					SeparateClauseWith: "\n",
+				},
+			},
+			qs: "SELECT users.name\nFROM users",
+		},
+	}
+	for _, test := range tests {
+		scanner := test.scanner
+		if scanner == nil {
+			scanner = defaultScanner
+		}
+		expArgc := len(test.qargs)
+		argc := test.s.argCount()
+		assert.Equal(expArgc, argc)
+
+		expLen := len(test.qs)
+		size := test.s.size(scanner)
+		size += interpolationLength(DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
+
+		b := make([]byte, size)
+		curArg := 0
+		written := test.s.scan(scanner, b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
+		assert.Equal(test.qs, string(b))
+	}
+}

--- a/function.go
+++ b/function.go
@@ -83,7 +83,7 @@ var (
 		// EXTRACT() which follows the following format:
 		// EXTRACT(field FROM [interval|timestamp] source)
 		FUNC_EXTRACT: scanInfo{
-			SYM_EXTRACT, SYM_PLACEHOLDER, SYM_FROM, SYM_ELEMENT, SYM_RPAREN,
+			SYM_EXTRACT, SYM_PLACEHOLDER, SYM_SPACE, SYM_FROM, SYM_ELEMENT, SYM_RPAREN,
 		},
 	}
 )

--- a/function.go
+++ b/function.go
@@ -93,20 +93,6 @@ type sqlFunc struct {
 	alias    string
 	scanInfo scanInfo
 	elements []element
-	dialect  Dialect
-}
-
-// Sets the sqlFunc's dialect and pushes the dialect down into any of the
-// sqlFunc's elements
-func (f *sqlFunc) setDialect(dialect Dialect) {
-	f.dialect = dialect
-	for _, el := range f.elements {
-		switch el.(type) {
-		case *value:
-			v := el.(*value)
-			v.dialect = dialect
-		}
-	}
 }
 
 func (f *sqlFunc) from() selection {
@@ -136,7 +122,7 @@ func (e *sqlFunc) argCount() int {
 	return ac
 }
 
-func (f *sqlFunc) size() int {
+func (f *sqlFunc) size(scanner *sqlScanner) int {
 	size := 0
 	elidx := 0
 	for _, sym := range f.scanInfo {
@@ -152,7 +138,7 @@ func (f *sqlFunc) size() int {
 				defer reset()
 			}
 			elidx++
-			size += el.size()
+			size += el.size(scanner)
 		default:
 			size += len(Symbols[sym])
 		}
@@ -163,7 +149,7 @@ func (f *sqlFunc) size() int {
 	return size
 }
 
-func (f *sqlFunc) scan(b []byte, args []interface{}, curArg *int) int {
+func (f *sqlFunc) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	elidx := 0
 	for _, sym := range f.scanInfo {
@@ -178,7 +164,7 @@ func (f *sqlFunc) scan(b []byte, args []interface{}, curArg *int) int {
 				defer reset()
 			}
 			elidx++
-			bw += el.scan(b[bw:], args, curArg)
+			bw += el.scan(scanner, b[bw:], args, curArg)
 		} else {
 			bw += copy(b[bw:], Symbols[sym])
 		}

--- a/function_test.go
+++ b/function_test.go
@@ -191,15 +191,17 @@ func TestFunctions(t *testing.T) {
 
 		// Test each SQL dialect output
 		for dialect, qs := range test.qs {
-			test.c.setDialect(dialect)
+			scanner := &sqlScanner{
+				dialect: dialect,
+			}
 			expLen := len(qs)
-			size := test.c.size()
+			size := test.c.size(scanner)
 			size += interpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			curArg := 0
-			written := test.c.scan(b, test.qargs, &curArg)
+			written := test.c.scan(scanner, b, test.qargs, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/group_by.go
+++ b/group_by.go
@@ -4,38 +4,30 @@ type groupByClause struct {
 	cols []projection
 }
 
-// Sets the statement's dialect and pushes the dialect down into any of the
-// statement's sub-clauses
-func (gb *groupByClause) setDialect(dialect Dialect) {
-	for _, c := range gb.cols {
-		c.(element).setDialect(dialect)
-	}
-}
-
 func (gb *groupByClause) argCount() int {
 	argc := 0
 	return argc
 }
 
-func (gb *groupByClause) size() int {
+func (gb *groupByClause) size(scanner *sqlScanner) int {
 	size := len(Symbols[SYM_GROUP_BY])
 	ncols := len(gb.cols)
 	for _, c := range gb.cols {
 		reset := c.disableAliasScan()
 		defer reset()
-		size += c.size()
+		size += c.size(scanner)
 	}
 	return size + (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (gb *groupByClause) scan(b []byte, args []interface{}, curArg *int) int {
+func (gb *groupByClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_GROUP_BY])
 	ncols := len(gb.cols)
 	for x, c := range gb.cols {
 		reset := c.disableAliasScan()
 		defer reset()
-		bw += c.scan(b[bw:], args, curArg)
+		bw += c.scan(scanner, b[bw:], args, curArg)
 		if x != (ncols - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -45,7 +45,7 @@ func TestGroupByClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size()
+		s := test.c.size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -53,7 +53,7 @@ func TestGroupByClause(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/insert.go
+++ b/insert.go
@@ -26,28 +26,24 @@ func (q *InsertQuery) Error() error {
 }
 
 func (q *InsertQuery) String() string {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *InsertQuery) StringArgs() (string, []interface{}) {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -8,6 +8,8 @@ type insertStatement struct {
 	values  []interface{}
 }
 
+func (s *insertStatement) setDialect(dialect Dialect) {}
+
 func (s *insertStatement) argCount() int {
 	return len(s.values)
 }

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -8,13 +8,11 @@ type insertStatement struct {
 	values  []interface{}
 }
 
-func (s *insertStatement) setDialect(dialect Dialect) {}
-
 func (s *insertStatement) argCount() int {
 	return len(s.values)
 }
 
-func (s *insertStatement) size() int {
+func (s *insertStatement) size(scanner *sqlScanner) int {
 	size := len(Symbols[SYM_INSERT]) + len(s.table.name) + 1 // space after table name
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -32,7 +30,7 @@ func (s *insertStatement) size() int {
 	return size
 }
 
-func (s *insertStatement) scan(b []byte, args []interface{}, curArg *int) int {
+func (s *insertStatement) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_INSERT])
 	// We don't add any table alias when outputting the table identifier
@@ -51,7 +49,7 @@ func (s *insertStatement) scan(b []byte, args []interface{}, curArg *int) int {
 	}
 	bw += copy(b[bw:], Symbols[SYM_VALUES])
 	for x, v := range s.values {
-		bw += scanInterpolationMarker(s.table.meta.dialect, b[bw:], *curArg)
+		bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
 		args[*curArg] = v
 		*curArg++
 		if x != (ncols - 1) {

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -57,13 +57,13 @@ func TestInsertStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size()
+		size := test.s.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(b, test.qargs, &curArg)
+		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,23 +7,20 @@ type Scannable interface {
 	// that the element should add its arguments to. The pointer to an int is
 	// the index of the current argument to be processed. The method returns a
 	// single int, the number of bytes written to the buffer.
-	scan([]byte, []interface{}, *int) int
+	scan(*sqlScanner, []byte, []interface{}, *int) int
 }
 
 type element interface {
 	// Returns the number of bytes that the scannable element would consume as
 	// a SQL string
-	size() int
+	size(*sqlScanner) int
 	// Returns the number of interface{} arguments that the element will add to
 	// the slice of interface{} arguments passed to Scan()
 	argCount() int
 	// scan takes two slices and a pointer to an int. The first slice is a slice of bytes that the
 	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
 	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
-	scan([]byte, []interface{}, *int) int
-	// Sets the element's SQL dialect and pushes the dialect down into any
-	// nested elements
-	setDialect(Dialect)
+	scan(*sqlScanner, []byte, []interface{}, *int) int
 }
 
 // A projection is something that produces a scalar value. A column, column
@@ -34,15 +31,12 @@ type element interface {
 type projection interface {
 	from() selection
 	// projections must also implement element
-	size() int
+	size(*sqlScanner) int
 	argCount() int
-	scan([]byte, []interface{}, *int) int
+	scan(*sqlScanner, []byte, []interface{}, *int) int
 	// disables the outputting of the "AS alias" extended output. Returns a
 	// function that resets the outputting of the "AS alias" extended output
 	disableAliasScan() func()
-	// Sets the element's SQL dialect and pushes the dialect down into any
-	// nested elements
-	setDialect(Dialect)
 }
 
 // A selection is something that produces rows. A table, table definition,
@@ -50,12 +44,9 @@ type projection interface {
 type selection interface {
 	projections() []projection
 	// selections must also implement element
-	size() int
+	size(*sqlScanner) int
 	argCount() int
-	scan([]byte, []interface{}, *int) int
-	// Sets the element's SQL dialect and pushes the dialect down into any
-	// nested elements
-	setDialect(Dialect)
+	scan(*sqlScanner, []byte, []interface{}, *int) int
 }
 
 // A Query is a placeholder for something that can be asked for the SQL string

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,5 +1,15 @@
 package sqlb
 
+type Scannable interface {
+	// scan takes two slices and a pointer to an int. The first slice is a
+	// slice of bytes that the implementation should copy its string
+	// representation to and the other slice is a slice of interface{} values
+	// that the element should add its arguments to. The pointer to an int is
+	// the index of the current argument to be processed. The method returns a
+	// single int, the number of bytes written to the buffer.
+	scan([]byte, []interface{}, *int) int
+}
+
 type element interface {
 	// Returns the number of bytes that the scannable element would consume as
 	// a SQL string

--- a/join.go
+++ b/join.go
@@ -23,7 +23,7 @@ func (j *joinClause) argCount() int {
 	return ac + j.left.argCount() + j.right.argCount()
 }
 
-func (j *joinClause) size() int {
+func (j *joinClause) size(scanner *sqlScanner) int {
 	size := 0
 	switch j.joinType {
 	case JOIN_INNER:
@@ -33,15 +33,15 @@ func (j *joinClause) size() int {
 	case JOIN_CROSS:
 		size += len(Symbols[SYM_CROSS_JOIN])
 		// CROSS JOIN has no ON condition so just short-circuit here
-		return size + j.right.size()
+		return size + j.right.size(scanner)
 	}
-	size += j.right.size()
+	size += j.right.size(scanner)
 	size += len(Symbols[SYM_ON])
-	size += j.on.size()
+	size += j.on.size(scanner)
 	return size
 }
 
-func (j *joinClause) scan(b []byte, args []interface{}, curArg *int) int {
+func (j *joinClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	switch j.joinType {
 	case JOIN_INNER:
@@ -51,10 +51,10 @@ func (j *joinClause) scan(b []byte, args []interface{}, curArg *int) int {
 	case JOIN_CROSS:
 		bw += copy(b[bw:], Symbols[SYM_CROSS_JOIN])
 	}
-	bw += j.right.scan(b[bw:], args, curArg)
+	bw += j.right.scan(scanner, b[bw:], args, curArg)
 	if j.on != nil {
 		bw += copy(b[bw:], Symbols[SYM_ON])
-		bw += j.on.scan(b[bw:], args, curArg)
+		bw += j.on.scan(scanner, b[bw:], args, curArg)
 	}
 	return bw
 }

--- a/join_test.go
+++ b/join_test.go
@@ -99,7 +99,7 @@ func TestJoinClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size()
+		s := test.c.size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -107,7 +107,7 @@ func TestJoinClause(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/limit.go
+++ b/limit.go
@@ -1,13 +1,8 @@
 package sqlb
 
 type limitClause struct {
-	limit   int
-	offset  *int
-	dialect Dialect
-}
-
-func (lc *limitClause) setDialect(dialect Dialect) {
-	lc.dialect = dialect
+	limit  int
+	offset *int
 }
 
 func (lc *limitClause) argCount() int {
@@ -17,7 +12,7 @@ func (lc *limitClause) argCount() int {
 	return 2
 }
 
-func (lc *limitClause) size() int {
+func (lc *limitClause) size(scanner *sqlScanner) int {
 	// Due to dialect handling, we do not include the length of interpolation
 	// markers for query parameters. This is calculated separately by the
 	// top-level scanning struct before malloc'ing the buffer to inject the SQL
@@ -29,15 +24,15 @@ func (lc *limitClause) size() int {
 	return size
 }
 
-func (lc *limitClause) scan(b []byte, args []interface{}, curArg *int) int {
+func (lc *limitClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_LIMIT])
-	bw += scanInterpolationMarker(lc.dialect, b[bw:], *curArg)
+	bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
 	args[*curArg] = lc.limit
 	*curArg++
 	if lc.offset != nil {
 		bw += copy(b[bw:], Symbols[SYM_OFFSET])
-		bw += scanInterpolationMarker(lc.dialect, b[bw:], *curArg)
+		bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
 		args[*curArg] = *lc.offset
 		*curArg++
 	}

--- a/limit_test.go
+++ b/limit_test.go
@@ -10,8 +10,7 @@ func TestLimitClause(t *testing.T) {
 	assert := assert.New(t)
 
 	lc := &limitClause{
-		limit:   20,
-		dialect: DIALECT_MYSQL,
+		limit: 20,
 	}
 
 	exp := " LIMIT ?"
@@ -20,7 +19,7 @@ func TestLimitClause(t *testing.T) {
 	argc := lc.argCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.size()
+	size := lc.size(defaultScanner)
 	size += interpolationLength(DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
@@ -28,7 +27,7 @@ func TestLimitClause(t *testing.T) {
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.scan(b, args, &curArg)
+	written := lc.scan(defaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))
@@ -39,8 +38,7 @@ func TestLimitClauseWithOffset(t *testing.T) {
 	assert := assert.New(t)
 
 	lc := &limitClause{
-		limit:   20,
-		dialect: DIALECT_MYSQL,
+		limit: 20,
 	}
 	offset := 10
 	lc.offset = &offset
@@ -51,7 +49,7 @@ func TestLimitClauseWithOffset(t *testing.T) {
 	argc := lc.argCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.size()
+	size := lc.size(defaultScanner)
 	size += interpolationLength(DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
@@ -59,7 +57,7 @@ func TestLimitClauseWithOffset(t *testing.T) {
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.scan(b, args, &curArg)
+	written := lc.scan(defaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))

--- a/list.go
+++ b/list.go
@@ -6,14 +6,6 @@ type List struct {
 	elements []element
 }
 
-// Sets the statement's dialect and pushes the dialect down into any of the
-// statement's sub-clauses
-func (l *List) setDialect(dialect Dialect) {
-	for _, el := range l.elements {
-		el.setDialect(dialect)
-	}
-}
-
 func (l *List) argCount() int {
 	ac := 0
 	for _, el := range l.elements {
@@ -22,20 +14,20 @@ func (l *List) argCount() int {
 	return ac
 }
 
-func (l *List) size() int {
+func (l *List) size(scanner *sqlScanner) int {
 	nels := len(l.elements)
 	size := 0
 	for _, el := range l.elements {
-		size += el.size()
+		size += el.size(scanner)
 	}
 	return size + (len(Symbols[SYM_COMMA_WS]) * (nels - 1)) // the commas...
 }
 
-func (l *List) scan(b []byte, args []interface{}, curArg *int) int {
+func (l *List) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	nels := len(l.elements)
 	for x, el := range l.elements {
-		bw += el.scan(b[bw:], args, curArg)
+		bw += el.scan(scanner, b[bw:], args, curArg)
 		if x != (nels - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}

--- a/list_test.go
+++ b/list_test.go
@@ -17,11 +17,11 @@ func TestListSingle(t *testing.T) {
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := cl.size()
+	s := cl.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.scan(b, nil, nil)
+	written := cl.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -39,11 +39,11 @@ func TestListMulti(t *testing.T) {
 
 	exp := "users.id, users.name"
 	expLen := len(exp)
-	s := cl.size()
+	s := cl.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.scan(b, nil, nil)
+	written := cl.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -59,7 +59,7 @@ func TestOrderBy(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size()
+		s := test.c.size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -67,7 +67,7 @@ func TestOrderBy(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/select.go
+++ b/select.go
@@ -27,28 +27,24 @@ func (q *SelectQuery) Error() error {
 }
 
 func (q *SelectQuery) String() string {
-	size := q.sel.size()
-	argc := q.sel.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.sel)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.sel)
 	return string(q.b)
 }
 
 func (q *SelectQuery) StringArgs() (string, []interface{}) {
-	size := q.sel.size()
-	argc := q.sel.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.sel)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.sel)
 	return string(q.b), q.args

--- a/select.go
+++ b/select.go
@@ -85,7 +85,6 @@ func (q *SelectQuery) As(alias string) *SelectQuery {
 	derivedSel := &selectStatement{
 		projs:      dt.getAllDerivedColumns(),
 		selections: []selection{dt},
-		scanner:    q.scanner,
 	}
 	return &SelectQuery{sel: derivedSel, scanner: q.scanner}
 }
@@ -257,8 +256,7 @@ func Select(items ...interface{}) *SelectQuery {
 		scanner: scanner,
 	}
 	sel := &selectStatement{
-		projs:   make([]projection, 0),
-		scanner: scanner,
+		projs: make([]projection, 0),
 	}
 
 	nDerived := 0

--- a/select.go
+++ b/select.go
@@ -29,7 +29,7 @@ func (q *SelectQuery) Error() error {
 func (q *SelectQuery) String() string {
 	size := q.sel.size()
 	argc := q.sel.argCount()
-	size += interpolationLength(q.scanner.dialect, argc)
+	size += q.scanner.interpolationLength(argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
@@ -43,7 +43,7 @@ func (q *SelectQuery) String() string {
 func (q *SelectQuery) StringArgs() (string, []interface{}) {
 	size := q.sel.size()
 	argc := q.sel.argCount()
-	size += interpolationLength(q.scanner.dialect, argc)
+	size += q.scanner.interpolationLength(argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}

--- a/select.go
+++ b/select.go
@@ -15,7 +15,7 @@ type SelectQuery struct {
 	b       []byte
 	args    []interface{}
 	sel     *selectStatement
-	dialect Dialect
+	scanner *sqlScanner
 }
 
 func (q *SelectQuery) IsValid() bool {
@@ -29,30 +29,28 @@ func (q *SelectQuery) Error() error {
 func (q *SelectQuery) String() string {
 	size := q.sel.size()
 	argc := q.sel.argCount()
-	size += interpolationLength(q.dialect, argc)
+	size += interpolationLength(q.scanner.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	curArg := 0
-	q.sel.scan(q.b, q.args, &curArg)
+	q.scanner.scan(q.b, q.args, q.sel)
 	return string(q.b)
 }
 
 func (q *SelectQuery) StringArgs() (string, []interface{}) {
 	size := q.sel.size()
 	argc := q.sel.argCount()
-	size += interpolationLength(q.dialect, argc)
+	size += interpolationLength(q.scanner.dialect, argc)
 	if len(q.args) != argc {
 		q.args = make([]interface{}, argc)
 	}
 	if len(q.b) != size {
 		q.b = make([]byte, size)
 	}
-	curArg := 0
-	q.sel.scan(q.b, q.args, &curArg)
+	q.scanner.scan(q.b, q.args, q.sel)
 	return string(q.b), q.args
 }
 
@@ -91,8 +89,9 @@ func (q *SelectQuery) As(alias string) *SelectQuery {
 	derivedSel := &selectStatement{
 		projs:      dt.getAllDerivedColumns(),
 		selections: []selection{dt},
+		scanner:    q.scanner,
 	}
-	return &SelectQuery{sel: derivedSel}
+	return &SelectQuery{sel: derivedSel, scanner: q.scanner}
 }
 
 // Returns the projection of the underlying selectStatement that matches the name
@@ -254,9 +253,16 @@ func (q *SelectQuery) doJoin(
 }
 
 func Select(items ...interface{}) *SelectQuery {
-	sq := &SelectQuery{dialect: DIALECT_UNKNOWN}
+	scanner := &sqlScanner{
+		dialect: DIALECT_UNKNOWN,
+		format:  defaultFormatOptions,
+	}
+	sq := &SelectQuery{
+		scanner: scanner,
+	}
 	sel := &selectStatement{
-		projs: make([]projection, 0),
+		projs:   make([]projection, 0),
+		scanner: scanner,
 	}
 
 	nDerived := 0
@@ -272,7 +278,7 @@ func Select(items ...interface{}) *SelectQuery {
 			// Project all columns from the subquery to the outer
 			// selectStatement
 			isq := item.(*SelectQuery)
-			sq.dialect = isq.dialect
+			sq.scanner = isq.scanner
 			innerSelClause := isq.sel
 			if len(innerSelClause.selections) == 1 {
 				innerSel := innerSelClause.selections[0]
@@ -316,12 +322,14 @@ func Select(items ...interface{}) *SelectQuery {
 			}
 		case *Column:
 			v := item.(*Column)
-			sq.dialect = v.tbl.meta.dialect
+			// Set scanner's dialect based on supplied meta's dialect
+			sq.scanner.dialect = v.tbl.meta.dialect
 			sel.projs = append(sel.projs, v)
 			selectionMap[v.tbl] = true
 		case *Table:
 			v := item.(*Table)
-			sq.dialect = v.meta.dialect
+			// Set scanner's dialect based on supplied meta's dialect
+			sq.scanner.dialect = v.meta.dialect
 			for _, c := range v.projections() {
 				addToProjections(sel, c)
 			}

--- a/select_statement.go
+++ b/select_statement.go
@@ -45,6 +45,7 @@ func (s *selectStatement) size(scanner *sqlScanner) int {
 	size += (len(Symbols[SYM_COMMA_WS]) * (nprojs - 1)) // the commas...
 	nsels := len(s.selections)
 	if nsels > 0 {
+		size += len(scanner.format.SeparateClauseWith)
 		size += len(Symbols[SYM_FROM])
 		for _, sel := range s.selections {
 			size += sel.size(scanner)
@@ -81,6 +82,7 @@ func (s *selectStatement) scan(scanner *sqlScanner, b []byte, args []interface{}
 	}
 	nsels := len(s.selections)
 	if nsels > 0 {
+		bw += copy(b[bw:], scanner.format.SeparateClauseWith)
 		bw += copy(b[bw:], Symbols[SYM_FROM])
 		for x, sel := range s.selections {
 			bw += sel.scan(scanner, b[bw:], args, curArg)

--- a/select_statement.go
+++ b/select_statement.go
@@ -8,13 +8,13 @@ type selectStatement struct {
 	groupBy    *groupByClause
 	orderBy    *orderByClause
 	limit      *limitClause
-	dialect    Dialect
+	scanner    *sqlScanner
 }
 
 // Sets the statement's dialect and pushes the dialect down into any of the
 // statement's sub-clauses
 func (s *selectStatement) setDialect(dialect Dialect) {
-	s.dialect = dialect
+	s.scanner.dialect = dialect
 	if s.where != nil {
 		s.where.setDialect(dialect)
 	}
@@ -186,14 +186,14 @@ func (s *selectStatement) addOrderBy(sortCols ...*sortColumn) *selectStatement {
 }
 
 func (s *selectStatement) setLimitWithOffset(limit int, offset int) *selectStatement {
-	lc := &limitClause{limit: limit, dialect: s.dialect}
+	lc := &limitClause{limit: limit, dialect: s.scanner.dialect}
 	lc.offset = &offset
 	s.limit = lc
 	return s
 }
 
 func (s *selectStatement) setLimit(limit int) *selectStatement {
-	lc := &limitClause{limit: limit, dialect: s.dialect}
+	lc := &limitClause{limit: limit, dialect: s.scanner.dialect}
 	s.limit = lc
 	return s
 }

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -194,13 +194,13 @@ func TestSelectClause(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size()
+		size := test.s.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(b, test.qargs, &curArg)
+		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/string_functions.go
+++ b/string_functions.go
@@ -92,7 +92,7 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 		} else {
 			// TRIM(LEADING remstr FROM string)
 			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_LEADING]) +
-				len(Symbols[SYM_FROM]) + 1)
+				len(Symbols[SYM_FROM]) + 2)
 		}
 	case TRIM_TRAILING:
 		if f.chars == "" {
@@ -101,7 +101,7 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 		} else {
 			// TRIM(TRAILING remstr FROM string)
 			size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_TRAILING]) +
-				len(Symbols[SYM_FROM]) + 1)
+				len(Symbols[SYM_FROM]) + 2)
 		}
 	case TRIM_BOTH:
 		if f.chars == "" {
@@ -109,7 +109,7 @@ func trimFuncSizeMySQL(f *trimFunc) int {
 			size = len(Symbols[SYM_TRIM])
 		} else {
 			// TRIM(remstr FROM string)
-			size = len(Symbols[SYM_TRIM]) + len(Symbols[SYM_FROM])
+			size = len(Symbols[SYM_TRIM]) + len(Symbols[SYM_FROM]) + 1
 		}
 	}
 	return size
@@ -127,10 +127,11 @@ func trimFuncScanMySQL(f *trimFunc, scanner *sqlScanner, b []byte, args []interf
 		} else {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
 			bw += copy(b[bw:], Symbols[SYM_LEADING])
-			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], " ")
 			bw += scanInterpolationMarker(DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
+			bw += copy(b[bw:], " ")
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
@@ -140,10 +141,11 @@ func trimFuncScanMySQL(f *trimFunc, scanner *sqlScanner, b []byte, args []interf
 		} else {
 			bw += copy(b[bw:], Symbols[SYM_TRIM])
 			bw += copy(b[bw:], Symbols[SYM_TRAILING])
-			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], " ")
 			bw += scanInterpolationMarker(DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
+			bw += copy(b[bw:], " ")
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
@@ -155,6 +157,7 @@ func trimFuncScanMySQL(f *trimFunc, scanner *sqlScanner, b []byte, args []interf
 			bw += scanInterpolationMarker(DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
+			bw += copy(b[bw:], " ")
 			bw += copy(b[bw:], Symbols[SYM_FROM])
 		}
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
@@ -170,7 +173,7 @@ func trimFuncSizePostgreSQL(f *trimFunc) int {
 	case TRIM_LEADING:
 		// TRIM(LEADING FROM string)
 		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_LEADING]) +
-			len(Symbols[SYM_FROM]))
+			len(Symbols[SYM_FROM]) + 1)
 		if f.chars != "" {
 			// TRIM(LEADING chars FROM string)
 			size += 1
@@ -178,7 +181,7 @@ func trimFuncSizePostgreSQL(f *trimFunc) int {
 	case TRIM_TRAILING:
 		// TRIM(TRAILING FROM string)
 		size = (len(Symbols[SYM_TRIM]) + len(Symbols[SYM_TRAILING]) +
-			len(Symbols[SYM_FROM]))
+			len(Symbols[SYM_FROM]) + 1)
 		if f.chars != "" {
 			// TRIM(TRAILING chars FROM string)
 			size += 1
@@ -205,22 +208,24 @@ func trimFuncScanPostgreSQL(f *trimFunc, scanner *sqlScanner, b []byte, args []i
 		bw += copy(b[bw:], Symbols[SYM_TRIM])
 		bw += copy(b[bw:], Symbols[SYM_LEADING])
 		if f.chars != "" {
-			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], " ")
 			bw += scanInterpolationMarker(DIALECT_POSTGRESQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 		}
+		bw += copy(b[bw:], " ")
 		bw += copy(b[bw:], Symbols[SYM_FROM])
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
 	case TRIM_TRAILING:
 		bw += copy(b[bw:], Symbols[SYM_TRIM])
 		bw += copy(b[bw:], Symbols[SYM_TRAILING])
 		if f.chars != "" {
-			bw += copy(b[bw:], []byte{' '})
+			bw += copy(b[bw:], " ")
 			bw += scanInterpolationMarker(DIALECT_POSTGRESQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 		}
+		bw += copy(b[bw:], " ")
 		bw += copy(b[bw:], Symbols[SYM_FROM])
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
 	case TRIM_BOTH:

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -78,16 +78,18 @@ func TestTrimFunctions(t *testing.T) {
 
 		// Test each SQL dialect output
 		for dialect, qs := range test.qs {
-			test.el.setDialect(dialect)
+			scanner := &sqlScanner{
+				dialect: dialect,
+			}
 			expLen := len(qs)
-			size := test.el.size()
+			size := test.el.size(scanner)
 			size += interpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			args := make([]interface{}, argc)
 			curArg := 0
-			written := test.el.scan(b, args, &curArg)
+			written := test.el.scan(scanner, b, args, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/symbol.go
+++ b/symbol.go
@@ -5,6 +5,7 @@ type scanInfo []Symbol
 
 const (
 	SYM_ELEMENT = iota // Marker for an element that self-scans into the SQL buffer
+	SYM_SPACE
 	SYM_QUEST_MARK
 	SYM_DOLLAR
 	SYM_PERIOD
@@ -174,12 +175,13 @@ var (
 var (
 	Symbols = map[Symbol][]byte{
 		SYM_QUEST_MARK:              []byte("?"),
+		SYM_SPACE:                   []byte(" "),
 		SYM_DOLLAR:                  []byte("$"),
 		SYM_PERIOD:                  []byte("."),
 		SYM_AS:                      []byte(" AS "),
 		SYM_COMMA_WS:                []byte(", "),
 		SYM_SELECT:                  []byte("SELECT "),
-		SYM_FROM:                    []byte(" FROM "),
+		SYM_FROM:                    []byte("FROM "),
 		SYM_JOIN:                    []byte(" JOIN "),
 		SYM_LEFT_JOIN:               []byte(" LEFT JOIN "),
 		SYM_CROSS_JOIN:              []byte(" CROSS JOIN "),

--- a/table.go
+++ b/table.go
@@ -7,14 +7,6 @@ type Table struct {
 	columns []*Column
 }
 
-// Sets the statement's dialect and pushes the dialect down into any of the
-// statement's sub-clauses
-func (t *Table) setDialect(dialect Dialect) {
-	for _, c := range t.columns {
-		c.setDialect(dialect)
-	}
-}
-
 // Return a pointer to a Column with a name or alias matching the supplied
 // string, or nil if no such column is known
 func (t *Table) C(name string) *Column {
@@ -51,7 +43,7 @@ func (t *Table) argCount() int {
 	return 0
 }
 
-func (t *Table) size() int {
+func (t *Table) size(scanner *sqlScanner) int {
 	size := len(t.name)
 	if t.alias != "" {
 		size += len(Symbols[SYM_AS]) + len(t.alias)
@@ -59,7 +51,7 @@ func (t *Table) size() int {
 	return size
 }
 
-func (t *Table) scan(b []byte, args []interface{}, curArg *int) int {
+func (t *Table) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := copy(b, t.name)
 	if t.alias != "" {
 		bw += copy(b[bw:], Symbols[SYM_AS])

--- a/table_test.go
+++ b/table_test.go
@@ -35,11 +35,11 @@ func TestTable(t *testing.T) {
 
 	exp := "users"
 	expLen := len(exp)
-	s := users.size()
+	s := users.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := users.scan(b, nil, nil)
+	written := users.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -53,11 +53,11 @@ func TestTableAlias(t *testing.T) {
 
 	exp := "users AS u"
 	expLen := len(exp)
-	s := u.size()
+	s := u.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := u.scan(b, nil, nil)
+	written := u.scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/update.go
+++ b/update.go
@@ -98,3 +98,7 @@ func Update(t *Table, values map[string]interface{}) *UpdateQuery {
 		scanner: scanner,
 	}
 }
+
+func (t *Table) Update(values map[string]interface{}) *UpdateQuery {
+	return Update(t, values)
+}

--- a/update.go
+++ b/update.go
@@ -27,28 +27,24 @@ func (q *UpdateQuery) Error() error {
 }
 
 func (q *UpdateQuery) String() string {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *UpdateQuery) StringArgs() (string, []interface{}) {
-	size := q.stmt.size()
-	argc := q.stmt.argCount()
-	size += q.scanner.interpolationLength(argc)
-	if len(q.args) != argc {
-		q.args = make([]interface{}, argc)
+	sizes := q.scanner.size(q.stmt)
+	if len(q.args) != sizes.ArgCount {
+		q.args = make([]interface{}, sizes.ArgCount)
 	}
-	if len(q.b) != size {
-		q.b = make([]byte, size)
+	if len(q.b) != sizes.BufferSize {
+		q.b = make([]byte, sizes.BufferSize)
 	}
 	q.scanner.scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args

--- a/update_statement.go
+++ b/update_statement.go
@@ -9,6 +9,8 @@ type updateStatement struct {
 	where   *whereClause
 }
 
+func (s *updateStatement) setDialect(dialect Dialect) {}
+
 func (s *updateStatement) argCount() int {
 	argc := len(s.values)
 	if s.where != nil {

--- a/update_statement.go
+++ b/update_statement.go
@@ -9,8 +9,6 @@ type updateStatement struct {
 	where   *whereClause
 }
 
-func (s *updateStatement) setDialect(dialect Dialect) {}
-
 func (s *updateStatement) argCount() int {
 	argc := len(s.values)
 	if s.where != nil {
@@ -19,7 +17,7 @@ func (s *updateStatement) argCount() int {
 	return argc
 }
 
-func (s *updateStatement) size() int {
+func (s *updateStatement) size(scanner *sqlScanner) int {
 	size := len(Symbols[SYM_UPDATE]) + len(s.table.name) + len(Symbols[SYM_SET])
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -34,12 +32,12 @@ func (s *updateStatement) size() int {
 	// values)
 	size += 2 * (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 	if s.where != nil {
-		size += s.where.size()
+		size += s.where.size(scanner)
 	}
 	return size
 }
 
-func (s *updateStatement) scan(b []byte, args []interface{}, curArg *int) int {
+func (s *updateStatement) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_UPDATE])
 	// We don't add any table alias when outputting the table identifier
@@ -53,7 +51,7 @@ func (s *updateStatement) scan(b []byte, args []interface{}, curArg *int) int {
 		// statement
 		bw += copy(b[bw:], c.name)
 		bw += copy(b[bw:], Symbols[SYM_EQUAL])
-		bw += scanInterpolationMarker(s.table.meta.dialect, b[bw:], *curArg)
+		bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
 		args[*curArg] = s.values[x]
 		*curArg++
 		if x != (ncols - 1) {
@@ -62,7 +60,7 @@ func (s *updateStatement) scan(b []byte, args []interface{}, curArg *int) int {
 	}
 
 	if s.where != nil {
-		bw += s.where.scan(b[bw:], args, curArg)
+		bw += s.where.scan(scanner, b[bw:], args, curArg)
 	}
 	return bw
 }

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -51,13 +51,13 @@ func TestUpdateStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size()
+		size := test.s.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(b, test.qargs, &curArg)
+		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/update_test.go
+++ b/update_test.go
@@ -42,6 +42,12 @@ func TestUpdateQuery(t *testing.T) {
 			qargs: []interface{}{"foo"},
 		},
 		{
+			name:  "UPDATE no WHERE using Table.Update()",
+			q:     users.Update(map[string]interface{}{"name": "foo"}),
+			qs:    "UPDATE users SET name = ?",
+			qargs: []interface{}{"foo"},
+		},
+		{
 			name: "UPDATE simple WHERE",
 			q: Update(users, map[string]interface{}{"name": "bar"}).Where(
 				Equal(colUserName, "foo"),

--- a/value_test.go
+++ b/value_test.go
@@ -15,7 +15,7 @@ func Testvalue(t *testing.T) {
 	expLen := len(exp)
 	expArgCount := 1
 
-	s := v.size()
+	s := v.size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	argc := v.argCount()
@@ -24,7 +24,7 @@ func Testvalue(t *testing.T) {
 	args := make([]interface{}, 1)
 	b := make([]byte, s)
 	curArg := 0
-	written := v.scan(b, args, &curArg)
+	written := v.scan(defaultScanner, b, args, &curArg)
 
 	assert.Equal(s, written)
 	assert.Equal(exp, string(b))

--- a/where_test.go
+++ b/where_test.go
@@ -115,13 +115,13 @@ func TestWhereClause(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size()
+		size := test.c.size(defaultScanner)
 		size += interpolationLength(DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(b, test.qargs, &curArg)
+		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))


### PR DESCRIPTION
Changes the way that sqlb generates the SQL buffer by decoupling the dialect and new FormatOptions processing from the way that the buffer's size and contents are created.

Issue #51