### PR TITLE
slowly tease apart common types/interfaces

### DIFF
--- a/column.go
+++ b/column.go
@@ -3,7 +3,12 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
+
 package sqlb
+
+import (
+	"github.com/jaypipes/sqlb/pkg/types"
+)
 
 type Column struct {
 	alias string
@@ -11,11 +16,11 @@ type Column struct {
 	tbl   *Table
 }
 
-func (c *Column) from() selection {
+func (c *Column) From() types.Selection {
 	return c.tbl
 }
 
-func (c *Column) disableAliasScan() func() {
+func (c *Column) DisableAliasScan() func() {
 	origAlias := c.alias
 	c.alias = ""
 	return func() { c.alias = origAlias }
@@ -25,11 +30,11 @@ func (c *Column) Column() *Column {
 	return c
 }
 
-func (c *Column) argCount() int {
+func (c *Column) ArgCount() int {
 	return 0
 }
 
-func (c *Column) size(scanner *sqlScanner) int {
+func (c *Column) Size(scanner types.Scanner) int {
 	size := 0
 	if c.tbl.alias != "" {
 		size += len(c.tbl.alias)
@@ -44,7 +49,7 @@ func (c *Column) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (c *Column) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (c *Column) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if c.tbl.alias != "" {
 		bw += copy(b[bw:], c.tbl.alias)

--- a/column_test.go
+++ b/column_test.go
@@ -19,11 +19,11 @@ func TestC(t *testing.T) {
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := c.size(defaultScanner)
+	s := c.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(defaultScanner, b, nil, nil)
+	written := c.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -37,11 +37,11 @@ func TestColumnWithTableAlias(t *testing.T) {
 
 	exp := "u.name"
 	expLen := len(exp)
-	s := c.size(defaultScanner)
+	s := c.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(defaultScanner, b, nil, nil)
+	written := c.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -55,11 +55,11 @@ func TestColumnAlias(t *testing.T) {
 
 	exp := "users.name AS user_name"
 	expLen := len(exp)
-	s := c.size(defaultScanner)
+	s := c.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.scan(defaultScanner, b, nil, nil)
+	written := c.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/delete.go
+++ b/delete.go
@@ -30,26 +30,26 @@ func (q *DeleteQuery) Error() error {
 }
 
 func (q *DeleteQuery) String() string {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *DeleteQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args
 }
 

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -3,7 +3,12 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
+
 package sqlb
+
+import (
+	"github.com/jaypipes/sqlb/pkg/types"
+)
 
 // DELETE FROM <table> WHERE <predicates>
 
@@ -12,29 +17,29 @@ type deleteStatement struct {
 	where *whereClause
 }
 
-func (s *deleteStatement) argCount() int {
+func (s *deleteStatement) ArgCount() int {
 	argc := 0
 	if s.where != nil {
-		argc += s.where.argCount()
+		argc += s.where.ArgCount()
 	}
 	return argc
 }
 
-func (s *deleteStatement) size(scanner *sqlScanner) int {
+func (s *deleteStatement) Size(scanner types.Scanner) int {
 	size := len(Symbols[SYM_DELETE]) + len(s.table.name)
 	if s.where != nil {
-		size += s.where.size(scanner)
+		size += s.where.Size(scanner)
 	}
 	return size
 }
 
-func (s *deleteStatement) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (s *deleteStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_DELETE])
 	// We don't add any table alias when outputting the table identifier
 	bw += copy(b[bw:], s.table.name)
 	if s.where != nil {
-		bw += s.where.scan(scanner, b[bw:], args, curArg)
+		bw += s.where.Scan(scanner, b[bw:], args, curArg)
 	}
 	return bw
 }

--- a/delete_statement_test.go
+++ b/delete_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,17 +48,17 @@ func TestDeleteStatement(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.s.argCount()
+		argc := test.s.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.s.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/derived.go
+++ b/derived.go
@@ -5,6 +5,8 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 // A derived table is a SELECT in the FROM clause. It is always aliased and the
 // projections for a derived table take this alias as their selection alias.
 //
@@ -26,9 +28,9 @@ type derivedTable struct {
 
 // Return a collection of derivedColumn projections that have been constructed
 // to refer to this derived table and not have any outer alias
-func (dt *derivedTable) getAllDerivedColumns() []projection {
+func (dt *derivedTable) getAllDerivedColumns() []types.Projection {
 	nprojs := len(dt.from.projs)
-	projs := make([]projection, nprojs)
+	projs := make([]types.Projection, nprojs)
 	for x := 0; x < nprojs; x++ {
 		p := dt.from.projs[x]
 		switch p.(type) {
@@ -39,9 +41,9 @@ func (dt *derivedTable) getAllDerivedColumns() []projection {
 	return projs
 }
 
-func (dt *derivedTable) projections() []projection {
+func (dt *derivedTable) Projections() []types.Projection {
 	nprojs := len(dt.from.projs)
-	projs := make([]projection, nprojs)
+	projs := make([]types.Projection, nprojs)
 	for x := 0; x < nprojs; x++ {
 		p := dt.from.projs[x]
 		switch p.(type) {
@@ -51,21 +53,21 @@ func (dt *derivedTable) projections() []projection {
 	return projs
 }
 
-func (dt *derivedTable) argCount() int {
-	return dt.from.argCount()
+func (dt *derivedTable) ArgCount() int {
+	return dt.from.ArgCount()
 }
 
-func (dt *derivedTable) size(scanner *sqlScanner) int {
-	size := dt.from.size(scanner)
+func (dt *derivedTable) Size(scanner types.Scanner) int {
+	size := dt.from.Size(scanner)
 	size += (len(Symbols[SYM_LPAREN]) + len(Symbols[SYM_RPAREN]) +
 		len(Symbols[SYM_AS]) + len(dt.alias))
 	return size
 }
 
-func (dt *derivedTable) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (dt *derivedTable) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_LPAREN])
-	bw += dt.from.scan(scanner, b[bw:], args, curArg)
+	bw += dt.from.Scan(scanner, b[bw:], args, curArg)
 	bw += copy(b[bw:], Symbols[SYM_RPAREN])
 	bw += copy(b[bw:], Symbols[SYM_AS])
 	bw += copy(b[bw:], dt.alias)
@@ -127,21 +129,21 @@ type derivedColumn struct {
 	dt    *derivedTable
 }
 
-func (dc *derivedColumn) from() selection {
+func (dc *derivedColumn) From() types.Selection {
 	return dc.dt
 }
 
-func (dc *derivedColumn) disableAliasScan() func() {
+func (dc *derivedColumn) DisableAliasScan() func() {
 	origAlias := dc.alias
 	dc.alias = ""
 	return func() { dc.alias = origAlias }
 }
 
-func (dc *derivedColumn) argCount() int {
+func (dc *derivedColumn) ArgCount() int {
 	return 0
 }
 
-func (dc *derivedColumn) size(scanner *sqlScanner) int {
+func (dc *derivedColumn) Size(scanner types.Scanner) int {
 	size := len(dc.dt.alias)
 	size += len(Symbols[SYM_PERIOD])
 	if dc.c.alias != "" {
@@ -155,7 +157,7 @@ func (dc *derivedColumn) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (dc *derivedColumn) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (dc *derivedColumn) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], dc.dt.alias)
 	bw += copy(b[bw:], Symbols[SYM_PERIOD])

--- a/derived_test.go
+++ b/derived_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,10 +30,10 @@ func TestDerived(t *testing.T) {
 		derivedTest{
 			c: &derivedTable{
 				from: &selectStatement{
-					projs: []projection{
+					projs: []types.Projection{
 						colUserName,
 					},
-					selections: []selection{
+					selections: []types.Selection{
 						users,
 					},
 				},
@@ -43,15 +44,15 @@ func TestDerived(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size(defaultScanner)
+		s := test.c.Size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		assert.Equal(expArgc, test.c.ArgCount())
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/dialect.go
+++ b/dialect.go
@@ -5,14 +5,10 @@
 //
 package sqlb
 
-import "strconv"
+import (
+	"strconv"
 
-type Dialect int
-
-const (
-	DIALECT_UNKNOWN = iota
-	DIALECT_MYSQL
-	DIALECT_POSTGRESQL
+	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 // Returns the total length of the characters representing interpolation
@@ -20,8 +16,8 @@ const (
 // sequences for marking query parameters during query preparation. For
 // instance, MySQL and SQLite use the ? character. PostgreSQL uses a numbered
 // $N schema with N starting at 1, SQL Server uses a :N scheme, etc.
-func interpolationLength(dialect Dialect, argc int) int {
-	if dialect == DIALECT_POSTGRESQL {
+func interpolationLength(dialect types.Dialect, argc int) int {
+	if dialect == types.DIALECT_POSTGRESQL {
 		// $ character for each interpolated parameter plus ones digit of
 		// number
 		size := 2 * argc
@@ -42,8 +38,8 @@ func interpolationLength(dialect Dialect, argc int) int {
 	return argc // Single question mark used as interpolation marker
 }
 
-func scanInterpolationMarker(dialect Dialect, b []byte, position int) int {
-	if dialect == DIALECT_POSTGRESQL {
+func scanInterpolationMarker(dialect types.Dialect, b []byte, position int) int {
+	if dialect == types.DIALECT_POSTGRESQL {
 		bw := copy(b, Symbols[SYM_DOLLAR])
 		bw += copy(b[bw:], []byte(strconv.Itoa(position+1)))
 		return bw

--- a/expression_test.go
+++ b/expression_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,17 +125,17 @@ func TestExpressions(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.c.argCount()
+		argc := test.c.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.c.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/format.go
+++ b/format.go
@@ -3,61 +3,60 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
+
 package sqlb
 
-type FormatOptions struct {
-	SeparateClauseWith string
-	PrefixWith         string
-}
+import (
+	"github.com/jaypipes/sqlb/pkg/types"
+)
 
-var defaultFormatOptions = &FormatOptions{
+var defaultFormatOptions = &types.FormatOptions{
 	SeparateClauseWith: " ",
 	PrefixWith:         "",
 }
 
 var defaultScanner = &sqlScanner{
-	dialect: DIALECT_MYSQL,
+	dialect: types.DIALECT_MYSQL,
 	format:  defaultFormatOptions,
-}
-
-type ElementSizes struct {
-	// The number of interface{} arguments that the element will add to the
-	// slice of interface{} arguments that will eventually be constructed for
-	// the Query
-	ArgCount int
-	// The number of bytes in the output buffer to represent this element
-	BufferSize int
 }
 
 // The struct that holds information about the formatting and dialect of the
 // output SQL that sqlb writes to the output buffer
 type sqlScanner struct {
-	dialect Dialect
-	format  *FormatOptions
+	dialect types.Dialect
+	format  *types.FormatOptions
 }
 
-func (s *sqlScanner) scan(b []byte, args []interface{}, scannables ...Scannable) {
+func (s *sqlScanner) Scan(b []byte, args []interface{}, scannables ...types.Scannable) {
 	curArg := 0
 	bw := 0
 	bw += copy(b[bw:], s.format.PrefixWith)
 	for _, scannable := range scannables {
-		bw += scannable.scan(s, b[bw:], args, &curArg)
+		bw += scannable.Scan(s, b[bw:], args, &curArg)
 	}
 }
 
-func (s *sqlScanner) size(elements ...element) *ElementSizes {
+func (s *sqlScanner) Size(elements ...types.Element) *types.ElementSizes {
 	buflen := 0
 	argc := 0
 
 	for _, el := range elements {
-		argc += el.argCount()
-		buflen += el.size(s)
+		argc += el.ArgCount()
+		buflen += el.Size(s)
 	}
 	buflen += interpolationLength(s.dialect, argc)
 	buflen += len(s.format.PrefixWith)
 
-	return &ElementSizes{
+	return &types.ElementSizes{
 		ArgCount:   argc,
 		BufferSize: buflen,
 	}
+}
+
+func (s *sqlScanner) Dialect() types.Dialect {
+	return s.dialect
+}
+
+func (s *sqlScanner) FormatOptions() *types.FormatOptions {
+	return s.format
 }

--- a/format_test.go
+++ b/format_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,8 +24,8 @@ func TestFormatOptions(t *testing.T) {
 	colArticleAuthor := articles.C("author")
 
 	stmt := &selectStatement{
-		selections: []selection{articles},
-		projs:      []projection{colArticleId, colUserName.As("author")},
+		selections: []types.Selection{articles},
+		projs:      []types.Projection{colArticleId, colUserName.As("author")},
 		joins: []*joinClause{
 			&joinClause{
 				left:  articles,
@@ -38,7 +39,7 @@ func TestFormatOptions(t *testing.T) {
 			},
 		},
 		groupBy: &groupByClause{
-			cols: []projection{colUserName},
+			cols: []types.Projection{colUserName},
 		},
 		orderBy: &orderByClause{
 			scols: []*sortColumn{colUserName.Desc()},
@@ -62,8 +63,8 @@ func TestFormatOptions(t *testing.T) {
 		{
 			name: "newline clause separator ",
 			scanner: &sqlScanner{
-				dialect: DIALECT_MYSQL,
-				format: &FormatOptions{
+				dialect: types.DIALECT_MYSQL,
+				format: &types.FormatOptions{
 					SeparateClauseWith: "\n",
 				},
 			},
@@ -80,8 +81,8 @@ LIMIT ?`,
 		{
 			name: "newline clause separator with prefix newline",
 			scanner: &sqlScanner{
-				dialect: DIALECT_MYSQL,
-				format: &FormatOptions{
+				dialect: types.DIALECT_MYSQL,
+				format: &types.FormatOptions{
 					SeparateClauseWith: "\n",
 					PrefixWith:         "\n",
 				},

--- a/function_test.go
+++ b/function_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,177 +22,177 @@ func TestFunctions(t *testing.T) {
 	tests := []struct {
 		name  string
 		c     *sqlFunc
-		qs    map[Dialect]string
+		qs    map[types.Dialect]string
 		qargs []interface{}
 	}{
 		{
 			name: "MAX(column)",
 			c:    Max(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "MAX(users.name)",
-				DIALECT_POSTGRESQL: "MAX(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "MAX(users.name)",
+				types.DIALECT_POSTGRESQL: "MAX(users.name)",
 			},
 		},
 		{
 			name: "aliased function",
 			c:    Max(colUserName).As("max_name"),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "MAX(users.name) AS max_name",
-				DIALECT_POSTGRESQL: "MAX(users.name) AS max_name",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "MAX(users.name) AS max_name",
+				types.DIALECT_POSTGRESQL: "MAX(users.name) AS max_name",
 			},
 		},
 		{
 			name: "MIN(column)",
 			c:    Min(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "MIN(users.name)",
-				DIALECT_POSTGRESQL: "MIN(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "MIN(users.name)",
+				types.DIALECT_POSTGRESQL: "MIN(users.name)",
 			},
 		},
 		{
 			name: "SUM(column)",
 			c:    Sum(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "SUM(users.name)",
-				DIALECT_POSTGRESQL: "SUM(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "SUM(users.name)",
+				types.DIALECT_POSTGRESQL: "SUM(users.name)",
 			},
 		},
 		{
 			name: "AVG(column)",
 			c:    Avg(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "AVG(users.name)",
-				DIALECT_POSTGRESQL: "AVG(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "AVG(users.name)",
+				types.DIALECT_POSTGRESQL: "AVG(users.name)",
 			},
 		},
 		{
 			name: "COUNT(*)",
 			c:    Count(users),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "COUNT(*)",
-				DIALECT_POSTGRESQL: "COUNT(*)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "COUNT(*)",
+				types.DIALECT_POSTGRESQL: "COUNT(*)",
 			},
 		},
 		{
 			name: "COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
-				DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
+				types.DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
 			},
 		},
 		{
 			name: "Ensure AS alias not in COUNT(DISTINCT column)",
 			c:    CountDistinct(colUserName.As("user_name")),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
-				DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "COUNT(DISTINCT users.name)",
+				types.DIALECT_POSTGRESQL: "COUNT(DISTINCT users.name)",
 			},
 		},
 		{
 			name: "CAST(column AS type)",
 			c:    Cast(colUserName, SQL_TYPE_TEXT),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CAST(users.name AS TEXT)",
-				DIALECT_POSTGRESQL: "CAST(users.name AS TEXT)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CAST(users.name AS TEXT)",
+				types.DIALECT_POSTGRESQL: "CAST(users.name AS TEXT)",
 			},
 		},
 		{
 			name: "CHAR_LENGTH(column)",
 			c:    CharLength(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CHAR_LENGTH(users.name)",
-				DIALECT_POSTGRESQL: "CHAR_LENGTH(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CHAR_LENGTH(users.name)",
+				types.DIALECT_POSTGRESQL: "CHAR_LENGTH(users.name)",
 			},
 		},
 		{
 			name: "BIT_LENGTH(column)",
 			c:    BitLength(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "BIT_LENGTH(users.name)",
-				DIALECT_POSTGRESQL: "BIT_LENGTH(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "BIT_LENGTH(users.name)",
+				types.DIALECT_POSTGRESQL: "BIT_LENGTH(users.name)",
 			},
 		},
 		{
 			name: "ASCII(column)",
 			c:    Ascii(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "ASCII(users.name)",
-				DIALECT_POSTGRESQL: "ASCII(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "ASCII(users.name)",
+				types.DIALECT_POSTGRESQL: "ASCII(users.name)",
 			},
 		},
 		{
 			name: "REVERSE(column)",
 			c:    Reverse(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "REVERSE(users.name)",
-				DIALECT_POSTGRESQL: "REVERSE(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "REVERSE(users.name)",
+				types.DIALECT_POSTGRESQL: "REVERSE(users.name)",
 			},
 		},
 		{
 			name: "CONCAT(column, column)",
 			c:    Concat(colUserName, colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CONCAT(users.name, users.name)",
-				DIALECT_POSTGRESQL: "CONCAT(users.name, users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CONCAT(users.name, users.name)",
+				types.DIALECT_POSTGRESQL: "CONCAT(users.name, users.name)",
 			},
 		},
 		{
 			name: "CONCAT_WS(string, column, column)",
 			c:    ConcatWs("-", colUserName, colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL: "CONCAT_WS(?, users.name, users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL: "CONCAT_WS(?, users.name, users.name)",
 				// Should be:
-				// DIALECT_POSTGRESQL: "CONCAT_WS($1, users.name, users.name)",
+				// types.DIALECT_POSTGRESQL: "CONCAT_WS($1, users.name, users.name)",
 			},
 			qargs: []interface{}{"-"},
 		},
 		{
 			name: "NOW()",
 			c:    Now(),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "NOW()",
-				DIALECT_POSTGRESQL: "NOW()",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "NOW()",
+				types.DIALECT_POSTGRESQL: "NOW()",
 			},
 		},
 		{
 			name: "CURRENT_TIMESTAMP()",
 			c:    CurrentTimestamp(),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CURRENT_TIMESTAMP()",
-				DIALECT_POSTGRESQL: "CURRENT_TIMESTAMP()",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CURRENT_TIMESTAMP()",
+				types.DIALECT_POSTGRESQL: "CURRENT_TIMESTAMP()",
 			},
 		},
 		{
 			name: "CURRENT_TIME()",
 			c:    CurrentTime(),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CURRENT_TIME()",
-				DIALECT_POSTGRESQL: "CURRENT_TIME()",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CURRENT_TIME()",
+				types.DIALECT_POSTGRESQL: "CURRENT_TIME()",
 			},
 		},
 		{
 			name: "CURRENT_DATE()",
 			c:    CurrentDate(),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "CURRENT_DATE()",
-				DIALECT_POSTGRESQL: "CURRENT_DATE()",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "CURRENT_DATE()",
+				types.DIALECT_POSTGRESQL: "CURRENT_DATE()",
 			},
 		},
 		{
 			name: "EXTRACT(unit FROM column)",
 			c:    Extract(colUserName, UNIT_MINUTE_SECOND),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
 				// Should be:
-				// DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM TIMESTAMP users.name)",
-				DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
+				// types.DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM TIMESTAMP users.name)",
+				types.DIALECT_POSTGRESQL: "EXTRACT(MINUTE_SECOND FROM users.name)",
 			},
 		},
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.c.argCount()
+		argc := test.c.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		// Test each SQL dialect output
@@ -200,13 +201,13 @@ func TestFunctions(t *testing.T) {
 				dialect: dialect,
 			}
 			expLen := len(qs)
-			size := test.c.size(scanner)
+			size := test.c.Size(scanner)
 			size += interpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			curArg := 0
-			written := test.c.scan(scanner, b, test.qargs, &curArg)
+			written := test.c.Scan(scanner, b, test.qargs, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/group_by.go
+++ b/group_by.go
@@ -5,37 +5,39 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type groupByClause struct {
-	cols []projection
+	cols []types.Projection
 }
 
-func (gb *groupByClause) argCount() int {
+func (gb *groupByClause) ArgCount() int {
 	argc := 0
 	return argc
 }
 
-func (gb *groupByClause) size(scanner *sqlScanner) int {
+func (gb *groupByClause) Size(scanner types.Scanner) int {
 	size := 0
-	size += len(scanner.format.SeparateClauseWith)
+	size += len(scanner.FormatOptions().SeparateClauseWith)
 	size += len(Symbols[SYM_GROUP_BY])
 	ncols := len(gb.cols)
 	for _, c := range gb.cols {
-		reset := c.disableAliasScan()
+		reset := c.DisableAliasScan()
 		defer reset()
-		size += c.size(scanner)
+		size += c.Size(scanner)
 	}
 	return size + (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (gb *groupByClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (gb *groupByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
-	bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], Symbols[SYM_GROUP_BY])
 	ncols := len(gb.cols)
 	for x, c := range gb.cols {
-		reset := c.disableAliasScan()
+		reset := c.DisableAliasScan()
 		defer reset()
-		bw += c.scan(scanner, b[bw:], args, curArg)
+		bw += c.Scan(scanner, b[bw:], args, curArg)
 		if x != (ncols - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,36 +30,36 @@ func TestGroupByClause(t *testing.T) {
 		// Single column
 		groupByClauseTest{
 			c: &groupByClause{
-				cols: []projection{colUserName},
+				cols: []types.Projection{colUserName},
 			},
 			qs: " GROUP BY users.name",
 		},
 		// Multiple columns
 		groupByClauseTest{
 			c: &groupByClause{
-				cols: []projection{colUserName, colUserId},
+				cols: []types.Projection{colUserName, colUserId},
 			},
 			qs: " GROUP BY users.name, users.id",
 		},
 		// Aliased column should NOT output alias in GROUP BY
 		groupByClauseTest{
 			c: &groupByClause{
-				cols: []projection{colUserName.As("user_name")},
+				cols: []types.Projection{colUserName.As("user_name")},
 			},
 			qs: " GROUP BY users.name",
 		},
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size(defaultScanner)
+		s := test.c.Size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		assert.Equal(expArgc, test.c.ArgCount())
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/having.go
+++ b/having.go
@@ -5,42 +5,44 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type havingClause struct {
 	conditions []*Expression
 }
 
-func (c *havingClause) argCount() int {
+func (c *havingClause) ArgCount() int {
 	argc := 0
 	for _, condition := range c.conditions {
-		argc += condition.argCount()
+		argc += condition.ArgCount()
 	}
 	return argc
 }
 
-func (c *havingClause) size(scanner *sqlScanner) int {
+func (c *havingClause) Size(scanner types.Scanner) int {
 	size := 0
 	nconditions := len(c.conditions)
 	if nconditions > 0 {
-		size += len(scanner.format.SeparateClauseWith)
+		size += len(scanner.FormatOptions().SeparateClauseWith)
 		size += len(Symbols[SYM_HAVING])
 		size += len(Symbols[SYM_AND]) * (nconditions - 1)
 		for _, condition := range c.conditions {
-			size += condition.size(scanner)
+			size += condition.Size(scanner)
 		}
 	}
 	return size
 }
 
-func (c *havingClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (c *havingClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if len(c.conditions) > 0 {
-		bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+		bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 		bw += copy(b[bw:], Symbols[SYM_HAVING])
 		for x, condition := range c.conditions {
 			if x > 0 {
 				bw += copy(b[bw:], Symbols[SYM_AND])
 			}
-			bw += condition.scan(scanner, b[bw:], args, curArg)
+			bw += condition.Scan(scanner, b[bw:], args, curArg)
 		}
 	}
 	return bw

--- a/having_test.go
+++ b/having_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,17 +114,17 @@ func TestHavingClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.c.argCount()
+		argc := test.c.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.c.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/insert.go
+++ b/insert.go
@@ -7,6 +7,8 @@ package sqlb
 
 import (
 	"errors"
+
+	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 var (
@@ -19,7 +21,7 @@ type InsertQuery struct {
 	b       []byte
 	args    []interface{}
 	stmt    *insertStatement
-	scanner *sqlScanner
+	scanner types.Scanner
 }
 
 func (q *InsertQuery) IsValid() bool {
@@ -31,26 +33,26 @@ func (q *InsertQuery) Error() error {
 }
 
 func (q *InsertQuery) String() string {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *InsertQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args
 }
 

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -5,6 +5,8 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 // INSERT INTO <table> (<columns>) VALUES (<values>)
 
 type insertStatement struct {
@@ -13,11 +15,11 @@ type insertStatement struct {
 	values  []interface{}
 }
 
-func (s *insertStatement) argCount() int {
+func (s *insertStatement) ArgCount() int {
 	return len(s.values)
 }
 
-func (s *insertStatement) size(scanner *sqlScanner) int {
+func (s *insertStatement) Size(scanner types.Scanner) int {
 	size := len(Symbols[SYM_INSERT]) + len(s.table.name) + 1 // space after table name
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -35,7 +37,7 @@ func (s *insertStatement) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (s *insertStatement) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (s *insertStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], Symbols[SYM_INSERT])
 	// We don't add any table alias when outputting the table identifier
@@ -54,7 +56,7 @@ func (s *insertStatement) scan(scanner *sqlScanner, b []byte, args []interface{}
 	}
 	bw += copy(b[bw:], Symbols[SYM_VALUES])
 	for x, v := range s.values {
-		bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
+		bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 		args[*curArg] = v
 		*curArg++
 		if x != (ncols - 1) {

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,17 +59,17 @@ func TestInsertStatement(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.s.argCount()
+		argc := test.s.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.s.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/join.go
+++ b/join.go
@@ -5,6 +5,8 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type joinType int
 
 const (
@@ -15,22 +17,22 @@ const (
 
 type joinClause struct {
 	joinType joinType
-	left     selection
-	right    selection
+	left     types.Selection
+	right    types.Selection
 	on       *Expression
 }
 
-func (j *joinClause) argCount() int {
+func (j *joinClause) ArgCount() int {
 	ac := 0
 	if j.on != nil {
-		ac = j.on.argCount()
+		ac = j.on.ArgCount()
 	}
-	return ac + j.left.argCount() + j.right.argCount()
+	return ac + j.left.ArgCount() + j.right.ArgCount()
 }
 
-func (j *joinClause) size(scanner *sqlScanner) int {
+func (j *joinClause) Size(scanner types.Scanner) int {
 	size := 0
-	size += len(scanner.format.SeparateClauseWith)
+	size += len(scanner.FormatOptions().SeparateClauseWith)
 	switch j.joinType {
 	case JOIN_INNER:
 		size += len(Symbols[SYM_JOIN])
@@ -39,17 +41,17 @@ func (j *joinClause) size(scanner *sqlScanner) int {
 	case JOIN_CROSS:
 		size += len(Symbols[SYM_CROSS_JOIN])
 		// CROSS JOIN has no ON condition so just short-circuit here
-		return size + j.right.size(scanner)
+		return size + j.right.Size(scanner)
 	}
-	size += j.right.size(scanner)
+	size += j.right.Size(scanner)
 	size += len(Symbols[SYM_ON])
-	size += j.on.size(scanner)
+	size += j.on.Size(scanner)
 	return size
 }
 
-func (j *joinClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (j *joinClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
-	bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	switch j.joinType {
 	case JOIN_INNER:
 		bw += copy(b[bw:], Symbols[SYM_JOIN])
@@ -58,19 +60,19 @@ func (j *joinClause) scan(scanner *sqlScanner, b []byte, args []interface{}, cur
 	case JOIN_CROSS:
 		bw += copy(b[bw:], Symbols[SYM_CROSS_JOIN])
 	}
-	bw += j.right.scan(scanner, b[bw:], args, curArg)
+	bw += j.right.Scan(scanner, b[bw:], args, curArg)
 	if j.on != nil {
 		bw += copy(b[bw:], Symbols[SYM_ON])
-		bw += j.on.scan(scanner, b[bw:], args, curArg)
+		bw += j.on.Scan(scanner, b[bw:], args, curArg)
 	}
 	return bw
 }
 
-func Join(left selection, right selection, on *Expression) *joinClause {
+func Join(left types.Selection, right types.Selection, on *Expression) *joinClause {
 	return &joinClause{left: left, right: right, on: on}
 }
 
-func OuterJoin(left selection, right selection, on *Expression) *joinClause {
+func OuterJoin(left types.Selection, right types.Selection, on *Expression) *joinClause {
 	return &joinClause{
 		joinType: JOIN_OUTER,
 		left:     left,
@@ -79,6 +81,6 @@ func OuterJoin(left selection, right selection, on *Expression) *joinClause {
 	}
 }
 
-func CrossJoin(left selection, right selection) *joinClause {
+func CrossJoin(left types.Selection, right types.Selection) *joinClause {
 	return &joinClause{joinType: JOIN_CROSS, left: left, right: right}
 }

--- a/join_test.go
+++ b/join_test.go
@@ -104,15 +104,15 @@ func TestJoinClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size(defaultScanner)
+		s := test.c.Size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		assert.Equal(expArgc, test.c.ArgCount())
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/limit.go
+++ b/limit.go
@@ -5,25 +5,27 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type limitClause struct {
 	limit  int
 	offset *int
 }
 
-func (lc *limitClause) argCount() int {
+func (lc *limitClause) ArgCount() int {
 	if lc.offset == nil {
 		return 1
 	}
 	return 2
 }
 
-func (lc *limitClause) size(scanner *sqlScanner) int {
+func (lc *limitClause) Size(scanner types.Scanner) int {
 	// Due to dialect handling, we do not include the length of interpolation
 	// markers for query parameters. This is calculated separately by the
 	// top-level scanning struct before malloc'ing the buffer to inject the SQL
 	// string into.
 	size := 0
-	size += len(scanner.format.SeparateClauseWith)
+	size += len(scanner.FormatOptions().SeparateClauseWith)
 	size += len(Symbols[SYM_LIMIT])
 	if lc.offset != nil {
 		size += len(Symbols[SYM_OFFSET])
@@ -31,16 +33,16 @@ func (lc *limitClause) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (lc *limitClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (lc *limitClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
-	bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], Symbols[SYM_LIMIT])
-	bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
+	bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 	args[*curArg] = lc.limit
 	*curArg++
 	if lc.offset != nil {
 		bw += copy(b[bw:], Symbols[SYM_OFFSET])
-		bw += scanInterpolationMarker(scanner.dialect, b[bw:], *curArg)
+		bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 		args[*curArg] = *lc.offset
 		*curArg++
 	}

--- a/limit_test.go
+++ b/limit_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,18 +22,18 @@ func TestLimitClause(t *testing.T) {
 	exp := " LIMIT ?"
 	expArgCount := 1
 
-	argc := lc.argCount()
+	argc := lc.ArgCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.size(defaultScanner)
-	size += interpolationLength(DIALECT_MYSQL, argc)
+	size := lc.Size(defaultScanner)
+	size += interpolationLength(types.DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
 
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.scan(defaultScanner, b, args, &curArg)
+	written := lc.Scan(defaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))
@@ -51,18 +52,18 @@ func TestLimitClauseWithOffset(t *testing.T) {
 	exp := " LIMIT ? OFFSET ?"
 	expArgCount := 2
 
-	argc := lc.argCount()
+	argc := lc.ArgCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.size(defaultScanner)
-	size += interpolationLength(DIALECT_MYSQL, argc)
+	size := lc.Size(defaultScanner)
+	size += interpolationLength(types.DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
 
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.scan(defaultScanner, b, args, &curArg)
+	written := lc.Scan(defaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))

--- a/list.go
+++ b/list.go
@@ -5,34 +5,36 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 // A List is a concrete struct wrapper around an array of elements that
 // implements the element interface.
 type List struct {
-	elements []element
+	elements []types.Element
 }
 
-func (l *List) argCount() int {
+func (l *List) ArgCount() int {
 	ac := 0
 	for _, el := range l.elements {
-		ac += el.argCount()
+		ac += el.ArgCount()
 	}
 	return ac
 }
 
-func (l *List) size(scanner *sqlScanner) int {
+func (l *List) Size(scanner types.Scanner) int {
 	nels := len(l.elements)
 	size := 0
 	for _, el := range l.elements {
-		size += el.size(scanner)
+		size += el.Size(scanner)
 	}
 	return size + (len(Symbols[SYM_COMMA_WS]) * (nels - 1)) // the commas...
 }
 
-func (l *List) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (l *List) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	nels := len(l.elements)
 	for x, el := range l.elements {
-		bw += el.scan(scanner, b[bw:], args, curArg)
+		bw += el.Scan(scanner, b[bw:], args, curArg)
 		if x != (nels - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}

--- a/list_test.go
+++ b/list_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,15 +19,15 @@ func TestListSingle(t *testing.T) {
 	users := m.Table("users")
 	colUserName := users.C("name")
 
-	cl := &List{elements: []element{colUserName}}
+	cl := &List{elements: []types.Element{colUserName}}
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := cl.size(defaultScanner)
+	s := cl.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.scan(defaultScanner, b, nil, nil)
+	written := cl.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -40,15 +41,15 @@ func TestListMulti(t *testing.T) {
 	colUserId := users.C("id")
 	colUserName := users.C("name")
 
-	cl := &List{elements: []element{colUserId, colUserName}}
+	cl := &List{elements: []types.Element{colUserId, colUserName}}
 
 	exp := "users.id, users.name"
 	expLen := len(exp)
-	s := cl.size(defaultScanner)
+	s := cl.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.scan(defaultScanner, b, nil, nil)
+	written := cl.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/meta_test.go
+++ b/meta_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -151,12 +152,12 @@ func testFixtureMeta() *Meta {
 	return meta
 }
 
-func resetDB(dialect Dialect, db *sql.DB) {
+func resetDB(dialect types.Dialect, db *sql.DB) {
 	var stmts []string
 	switch dialect {
-	case DIALECT_MYSQL:
+	case types.DIALECT_MYSQL:
 		stmts = _MYSQL_DB_INIT
-	case DIALECT_POSTGRESQL:
+	case types.DIALECT_POSTGRESQL:
 		stmts = _POSTGRESQL_DB_INIT
 	}
 	for _, stmt := range stmts {
@@ -177,10 +178,10 @@ func TestReflectMySQL(t *testing.T) {
 	db, err := sql.Open("mysql", dsn)
 	assert.Nil(err)
 
-	resetDB(DIALECT_MYSQL, db)
+	resetDB(types.DIALECT_MYSQL, db)
 
 	var meta Meta
-	err = Reflect(DIALECT_MYSQL, db, &meta)
+	err = Reflect(types.DIALECT_MYSQL, db, &meta)
 	assert.Nil(err)
 
 	assert.Equal(2, len(meta.tables))
@@ -209,10 +210,10 @@ func TestReflectPostgreSQL(t *testing.T) {
 	db, err := sql.Open("postgres", dsn)
 	assert.Nil(err)
 
-	resetDB(DIALECT_POSTGRESQL, db)
+	resetDB(types.DIALECT_POSTGRESQL, db)
 
 	var meta Meta
-	err = Reflect(DIALECT_POSTGRESQL, db, &meta)
+	err = Reflect(types.DIALECT_POSTGRESQL, db, &meta)
 	assert.Nil(err)
 
 	assert.Equal(2, len(meta.tables))
@@ -234,7 +235,7 @@ func TestReflectPostgreSQL(t *testing.T) {
 func TestReflectErrors(t *testing.T) {
 	assert := assert.New(t)
 
-	err := Reflect(DIALECT_MYSQL, nil, nil)
+	err := Reflect(types.DIALECT_MYSQL, nil, nil)
 	assert.NotNil(err)
 	assert.Equal(ERR_NO_META_STRUCT, err)
 }

--- a/order_by.go
+++ b/order_by.go
@@ -5,30 +5,32 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type sortColumn struct {
-	p    projection
+	p    types.Projection
 	desc bool
 }
 
-func (sc *sortColumn) argCount() int {
-	return sc.p.argCount()
+func (sc *sortColumn) ArgCount() int {
+	return sc.p.ArgCount()
 }
 
-func (sc *sortColumn) size(scanner *sqlScanner) int {
-	reset := sc.p.disableAliasScan()
+func (sc *sortColumn) Size(scanner types.Scanner) int {
+	reset := sc.p.DisableAliasScan()
 	defer reset()
-	size := sc.p.size(scanner)
+	size := sc.p.Size(scanner)
 	if sc.desc {
 		size += len(Symbols[SYM_DESC])
 	}
 	return size
 }
 
-func (sc *sortColumn) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
-	reset := sc.p.disableAliasScan()
+func (sc *sortColumn) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+	reset := sc.p.DisableAliasScan()
 	defer reset()
 	bw := 0
-	bw += sc.p.scan(scanner, b[bw:], args, curArg)
+	bw += sc.p.Scan(scanner, b[bw:], args, curArg)
 	if sc.desc {
 		bw += copy(b[bw:], Symbols[SYM_DESC])
 	}
@@ -39,29 +41,29 @@ type orderByClause struct {
 	scols []*sortColumn
 }
 
-func (ob *orderByClause) argCount() int {
+func (ob *orderByClause) ArgCount() int {
 	argc := 0
 	return argc
 }
 
-func (ob *orderByClause) size(scanner *sqlScanner) int {
+func (ob *orderByClause) Size(scanner types.Scanner) int {
 	size := 0
-	size += len(scanner.format.SeparateClauseWith)
+	size += len(scanner.FormatOptions().SeparateClauseWith)
 	size += len(Symbols[SYM_ORDER_BY])
 	ncols := len(ob.scols)
 	for _, sc := range ob.scols {
-		size += sc.size(scanner)
+		size += sc.Size(scanner)
 	}
 	return size + (len(Symbols[SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (ob *orderByClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (ob *orderByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
-	bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], Symbols[SYM_ORDER_BY])
 	ncols := len(ob.scols)
 	for x, sc := range ob.scols {
-		bw += sc.scan(scanner, b[bw:], args, curArg)
+		bw += sc.Scan(scanner, b[bw:], args, curArg)
 		if x != (ncols - 1) {
 			bw += copy(b[bw:], Symbols[SYM_COMMA_WS])
 		}

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -64,15 +64,15 @@ func TestOrderBy(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.size(defaultScanner)
+		s := test.c.Size(defaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
-		assert.Equal(expArgc, test.c.argCount())
+		assert.Equal(expArgc, test.c.ArgCount())
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/pkg/types/dialect.go
+++ b/pkg/types/dialect.go
@@ -1,0 +1,15 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package types
+
+type Dialect int
+
+const (
+	DIALECT_UNKNOWN = iota
+	DIALECT_MYSQL
+	DIALECT_POSTGRESQL
+)

--- a/pkg/types/format_options.go
+++ b/pkg/types/format_options.go
@@ -1,0 +1,12 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package types
+
+type FormatOptions struct {
+	SeparateClauseWith string
+	PrefixWith         string
+}

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -3,7 +3,8 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
-package sqlb
+
+package types
 
 type Scannable interface {
 	// scan takes two slices and a pointer to an int. The first slice is a
@@ -12,20 +13,20 @@ type Scannable interface {
 	// that the element should add its arguments to. The pointer to an int is
 	// the index of the current argument to be processed. The method returns a
 	// single int, the number of bytes written to the buffer.
-	scan(*sqlScanner, []byte, []interface{}, *int) int
+	Scan(Scanner, []byte, []interface{}, *int) int
 }
 
-type element interface {
+type Element interface {
 	// Returns the number of bytes that the scannable element would consume as
 	// a SQL string
-	size(*sqlScanner) int
+	Size(Scanner) int
 	// Returns the number of interface{} arguments that the element will add to
 	// the slice of interface{} arguments passed to Scan()
-	argCount() int
+	ArgCount() int
 	// scan takes two slices and a pointer to an int. The first slice is a slice of bytes that the
 	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
 	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
-	scan(*sqlScanner, []byte, []interface{}, *int) int
+	Scan(Scanner, []byte, []interface{}, *int) int
 }
 
 // A projection is something that produces a scalar value. A column, column
@@ -33,25 +34,25 @@ type element interface {
 // list, the projection will output itself using the "AS alias" extended
 // notation. When outputting in GROUP BY, ORDER BY or ON clauses, the
 // projection will not include the alias extension
-type projection interface {
-	from() selection
+type Projection interface {
+	From() Selection
 	// projections must also implement element
-	size(*sqlScanner) int
-	argCount() int
-	scan(*sqlScanner, []byte, []interface{}, *int) int
+	Size(Scanner) int
+	ArgCount() int
+	Scan(Scanner, []byte, []interface{}, *int) int
 	// disables the outputting of the "AS alias" extended output. Returns a
 	// function that resets the outputting of the "AS alias" extended output
-	disableAliasScan() func()
+	DisableAliasScan() func()
 }
 
 // A selection is something that produces rows. A table, table definition,
 // view, subselect, etc.
-type selection interface {
-	projections() []projection
+type Selection interface {
+	Projections() []Projection
 	// selections must also implement element
-	size(*sqlScanner) int
-	argCount() int
-	scan(*sqlScanner, []byte, []interface{}, *int) int
+	Size(Scanner) int
+	ArgCount() int
+	Scan(Scanner, []byte, []interface{}, *int) int
 }
 
 // A Query is a placeholder for something that can be asked for the SQL string

--- a/pkg/types/scanner.go
+++ b/pkg/types/scanner.go
@@ -1,0 +1,26 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package types
+
+type ElementSizes struct {
+	// The number of interface{} arguments that the element will add to the
+	// slice of interface{} arguments that will eventually be constructed for
+	// the Query
+	ArgCount int
+	// The number of bytes in the output buffer to represent this element
+	BufferSize int
+}
+
+type Scanner interface {
+	// Scan takes two slices and a pointer to an int. The first slice is a slice of bytes that the
+	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
+	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
+	Scan([]byte, []interface{}, ...Scannable)
+	Size(...Element) *ElementSizes
+	Dialect() Dialect
+	FormatOptions() *FormatOptions
+}

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,65 +21,65 @@ func TestTrimFunctions(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		el    element
-		qs    map[Dialect]string
+		el    types.Element
+		qs    map[types.Dialect]string
 		qargs []interface{}
 	}{
 		{
 			name: "TRIM(column) or BTRIM(column)",
 			el:   Trim(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "TRIM(users.name)",
-				DIALECT_POSTGRESQL: "BTRIM(users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "TRIM(users.name)",
+				types.DIALECT_POSTGRESQL: "BTRIM(users.name)",
 			},
 		},
 		{
 			name: "LTRIM(column) or TRIM(LEADING FROM column)",
 			el:   LTrim(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "LTRIM(users.name)",
-				DIALECT_POSTGRESQL: "TRIM(LEADING FROM users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "LTRIM(users.name)",
+				types.DIALECT_POSTGRESQL: "TRIM(LEADING FROM users.name)",
 			},
 		},
 		{
 			name: "RTRIM(column) or TRIM(TRAILING FROM column)",
 			el:   RTrim(colUserName),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "RTRIM(users.name)",
-				DIALECT_POSTGRESQL: "TRIM(TRAILING FROM users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "RTRIM(users.name)",
+				types.DIALECT_POSTGRESQL: "TRIM(TRAILING FROM users.name)",
 			},
 		},
 		{
 			name: "TRIM(remstr FROM column) OR BTRIM(column, chars)",
 			el:   TrimChars(colUserName, "xyz"),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "TRIM(? FROM users.name)",
-				DIALECT_POSTGRESQL: "BTRIM(users.name, $1)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "TRIM(? FROM users.name)",
+				types.DIALECT_POSTGRESQL: "BTRIM(users.name, $1)",
 			},
 			qargs: []interface{}{"xyz"},
 		},
 		{
 			name: "TRIM(LEADING remstr FROM column)",
 			el:   LTrimChars(colUserName, "xyz"),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "TRIM(LEADING ? FROM users.name)",
-				DIALECT_POSTGRESQL: "TRIM(LEADING $1 FROM users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "TRIM(LEADING ? FROM users.name)",
+				types.DIALECT_POSTGRESQL: "TRIM(LEADING $1 FROM users.name)",
 			},
 			qargs: []interface{}{"xyz"},
 		},
 		{
 			name: "TRIM(TRAILING remstr FROM column)",
 			el:   RTrimChars(colUserName, "xyz"),
-			qs: map[Dialect]string{
-				DIALECT_MYSQL:      "TRIM(TRAILING ? FROM users.name)",
-				DIALECT_POSTGRESQL: "TRIM(TRAILING $1 FROM users.name)",
+			qs: map[types.Dialect]string{
+				types.DIALECT_MYSQL:      "TRIM(TRAILING ? FROM users.name)",
+				types.DIALECT_POSTGRESQL: "TRIM(TRAILING $1 FROM users.name)",
 			},
 			qargs: []interface{}{"xyz"},
 		},
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.el.argCount()
+		argc := test.el.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		// Test each SQL dialect output
@@ -87,14 +88,14 @@ func TestTrimFunctions(t *testing.T) {
 				dialect: dialect,
 			}
 			expLen := len(qs)
-			size := test.el.size(scanner)
+			size := test.el.Size(scanner)
 			size += interpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			args := make([]interface{}, argc)
 			curArg := 0
-			written := test.el.scan(scanner, b, args, &curArg)
+			written := test.el.Scan(scanner, b, args, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/table.go
+++ b/table.go
@@ -5,6 +5,8 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type Table struct {
 	alias   string
 	meta    *Meta
@@ -36,19 +38,19 @@ func (t *Table) NewColumn(name string) *Column {
 	return c
 }
 
-func (t *Table) projections() []projection {
-	res := make([]projection, len(t.columns))
+func (t *Table) Projections() []types.Projection {
+	res := make([]types.Projection, len(t.columns))
 	for x, c := range t.columns {
 		res[x] = c
 	}
 	return res
 }
 
-func (t *Table) argCount() int {
+func (t *Table) ArgCount() int {
 	return 0
 }
 
-func (t *Table) size(scanner *sqlScanner) int {
+func (t *Table) Size(scanner types.Scanner) int {
 	size := len(t.name)
 	if t.alias != "" {
 		size += len(Symbols[SYM_AS]) + len(t.alias)
@@ -56,7 +58,7 @@ func (t *Table) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (t *Table) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (t *Table) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := copy(b, t.name)
 	if t.alias != "" {
 		bw += copy(b[bw:], Symbols[SYM_AS])

--- a/table_test.go
+++ b/table_test.go
@@ -8,13 +8,14 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTableMeta(t *testing.T) {
 	assert := assert.New(t)
 
-	m := NewMeta(DIALECT_MYSQL, "test")
+	m := NewMeta(types.DIALECT_MYSQL, "test")
 	td := m.Table("users")
 	assert.Nil(td)
 	td = m.NewTable("users")
@@ -40,11 +41,11 @@ func TestTable(t *testing.T) {
 
 	exp := "users"
 	expLen := len(exp)
-	s := users.size(defaultScanner)
+	s := users.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := users.scan(defaultScanner, b, nil, nil)
+	written := users.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -58,11 +59,11 @@ func TestTableAlias(t *testing.T) {
 
 	exp := "users AS u"
 	expLen := len(exp)
-	s := u.size(defaultScanner)
+	s := u.Size(defaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := u.scan(defaultScanner, b, nil, nil)
+	written := u.Scan(defaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/update.go
+++ b/update.go
@@ -32,26 +32,26 @@ func (q *UpdateQuery) Error() error {
 }
 
 func (q *UpdateQuery) String() string {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b)
 }
 
 func (q *UpdateQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.size(q.stmt)
+	sizes := q.scanner.Size(q.stmt)
 	if len(q.args) != sizes.ArgCount {
 		q.args = make([]interface{}, sizes.ArgCount)
 	}
 	if len(q.b) != sizes.BufferSize {
 		q.b = make([]byte, sizes.BufferSize)
 	}
-	q.scanner.scan(q.b, q.args, q.stmt)
+	q.scanner.Scan(q.b, q.args, q.stmt)
 	return string(q.b), q.args
 }
 

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,17 +53,17 @@ func TestUpdateStatement(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.s.argCount()
+		argc := test.s.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.s.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/util.go
+++ b/util.go
@@ -5,15 +5,17 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 // Given a slice of interface{} variables, returns a slice of element members.
 // If any of the interface{} variables are *not* of type element already, we
 // construct a Value{} for the variable.
-func toElements(vars ...interface{}) []element {
-	els := make([]element, len(vars))
+func toElements(vars ...interface{}) []types.Element {
+	els := make([]types.Element, len(vars))
 	for x, v := range vars {
 		switch v.(type) {
-		case element:
-			els[x] = v.(element)
+		case types.Element:
+			els[x] = v.(types.Element)
 		default:
 			els[x] = &value{val: v}
 		}
@@ -26,7 +28,7 @@ func toElements(vars ...interface{}) []element {
 // If any of the interface{} variables are *not* of type element already, we
 // construct a Value{} for the variable.
 func toValueList(vars ...interface{}) *List {
-	els := make([]element, len(vars))
+	els := make([]types.Element, len(vars))
 	for x, v := range vars {
 		els[x] = &value{val: v}
 	}

--- a/value.go
+++ b/value.go
@@ -5,17 +5,19 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 // A value is a concrete struct wrapper around a constant that implements the
 // scannable interface. Typically, users won't directly construct value
 // structs but instead helper functions like sqlb.Equal() will construct a
 // value and bind it to the containing element.
 type value struct {
-	sel   selection
+	sel   types.Selection
 	alias string
 	val   interface{}
 }
 
-func (v *value) from() selection {
+func (v *value) From() types.Selection {
 	return v.sel
 }
 
@@ -31,17 +33,17 @@ func (v *value) As(alias string) *value {
 	}
 }
 
-func (v *value) disableAliasScan() func() {
+func (v *value) DisableAliasScan() func() {
 	origAlias := v.alias
 	v.alias = ""
 	return func() { v.alias = origAlias }
 }
 
-func (v *value) argCount() int {
+func (v *value) ArgCount() int {
 	return 1
 }
 
-func (v *value) size(scanner *sqlScanner) int {
+func (v *value) Size(scanner types.Scanner) int {
 	// Due to dialect handling, we do not include the length of interpolation
 	// markers for query parameters. This is calculated separately by the
 	// top-level scanning struct before malloc'ing the buffer to inject the SQL
@@ -53,9 +55,9 @@ func (v *value) size(scanner *sqlScanner) int {
 	return size
 }
 
-func (v *value) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (v *value) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	args[*curArg] = v.val
-	bw := scanInterpolationMarker(scanner.dialect, b, *curArg)
+	bw := scanInterpolationMarker(scanner.Dialect(), b, *curArg)
 	*curArg++
 	if v.alias != "" {
 		bw += copy(b[bw:], Symbols[SYM_AS])

--- a/value_test.go
+++ b/value_test.go
@@ -16,18 +16,18 @@ func TestValue(t *testing.T) {
 
 	v := &value{val: "foo"}
 
-	s := v.size(defaultScanner)
+	s := v.Size(defaultScanner)
 	// Due to dialect handling, we can't include interpolation markers in the
 	// size calculation, so size() always returns 0 for non-aliased values.
 	assert.Equal(0, s)
 
-	argc := v.argCount()
+	argc := v.ArgCount()
 	assert.Equal(1, argc)
 
 	args := make([]interface{}, 1)
 	b := make([]byte, 1)
 	curArg := 0
-	written := v.scan(defaultScanner, b, args, &curArg)
+	written := v.Scan(defaultScanner, b, args, &curArg)
 
 	exp := "?"
 	expLen := len(exp)

--- a/where.go
+++ b/where.go
@@ -5,42 +5,44 @@
 //
 package sqlb
 
+import "github.com/jaypipes/sqlb/pkg/types"
+
 type whereClause struct {
 	filters []*Expression
 }
 
-func (w *whereClause) argCount() int {
+func (w *whereClause) ArgCount() int {
 	argc := 0
 	for _, filter := range w.filters {
-		argc += filter.argCount()
+		argc += filter.ArgCount()
 	}
 	return argc
 }
 
-func (w *whereClause) size(scanner *sqlScanner) int {
+func (w *whereClause) Size(scanner types.Scanner) int {
 	size := 0
 	nfilters := len(w.filters)
 	if nfilters > 0 {
-		size += len(scanner.format.SeparateClauseWith)
+		size += len(scanner.FormatOptions().SeparateClauseWith)
 		size += len(Symbols[SYM_WHERE])
 		size += len(Symbols[SYM_AND]) * (nfilters - 1)
 		for _, filter := range w.filters {
-			size += filter.size(scanner)
+			size += filter.Size(scanner)
 		}
 	}
 	return size
 }
 
-func (w *whereClause) scan(scanner *sqlScanner, b []byte, args []interface{}, curArg *int) int {
+func (w *whereClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if len(w.filters) > 0 {
-		bw += copy(b[bw:], scanner.format.SeparateClauseWith)
+		bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 		bw += copy(b[bw:], Symbols[SYM_WHERE])
 		for x, filter := range w.filters {
 			if x > 0 {
 				bw += copy(b[bw:], Symbols[SYM_AND])
 			}
-			bw += filter.scan(scanner, b[bw:], args, curArg)
+			bw += filter.Scan(scanner, b[bw:], args, curArg)
 		}
 	}
 	return bw

--- a/where_test.go
+++ b/where_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,17 +117,17 @@ func TestWhereClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expArgc := len(test.qargs)
-		argc := test.c.argCount()
+		argc := test.c.ArgCount()
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.size(defaultScanner)
-		size += interpolationLength(DIALECT_MYSQL, argc)
+		size := test.c.Size(defaultScanner)
+		size += interpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))


### PR DESCRIPTION
Moves the primary interfaces into a `pkg/types` package and makes a new
Scanner interface that the old sqlScanner struct is modeled after. The
majority of this patch simply renames methods or moves package imports.