### PR TITLE
preparation for pkg/grammar/clause breakout

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,11 +20,11 @@ func TestC(t *testing.T) {
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := c.Size(defaultScanner)
+	s := c.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.Scan(defaultScanner, b, nil, nil)
+	written := c.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -37,11 +38,11 @@ func TestColumnWithTableAlias(t *testing.T) {
 
 	exp := "u.name"
 	expLen := len(exp)
-	s := c.Size(defaultScanner)
+	s := c.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.Scan(defaultScanner, b, nil, nil)
+	written := c.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -55,11 +56,11 @@ func TestColumnAlias(t *testing.T) {
 
 	exp := "users.name AS user_name"
 	expLen := len(exp)
-	s := c.Size(defaultScanner)
+	s := c.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := c.Scan(defaultScanner, b, nil, nil)
+	written := c.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/delete.go
+++ b/delete.go
@@ -7,6 +7,9 @@ package sqlb
 
 import (
 	"errors"
+
+	"github.com/jaypipes/sqlb/pkg/scanner"
+	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 var (
@@ -18,7 +21,7 @@ type DeleteQuery struct {
 	b       []byte
 	args    []interface{}
 	stmt    *DeleteStatement
-	scanner *sqlScanner
+	scanner types.Scanner
 }
 
 func (q *DeleteQuery) IsValid() bool {
@@ -65,10 +68,7 @@ func Delete(t *Table) *DeleteQuery {
 		return &DeleteQuery{e: ERR_DELETE_NO_TARGET}
 	}
 
-	scanner := &sqlScanner{
-		dialect: t.meta.dialect,
-		format:  defaultFormatOptions,
-	}
+	scanner := scanner.New(t.meta.dialect)
 	stmt := &DeleteStatement{
 		table: t,
 	}

--- a/delete.go
+++ b/delete.go
@@ -17,7 +17,7 @@ type DeleteQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	stmt    *deleteStatement
+	stmt    *DeleteStatement
 	scanner *sqlScanner
 }
 
@@ -54,7 +54,7 @@ func (q *DeleteQuery) StringArgs() (string, []interface{}) {
 }
 
 func (q *DeleteQuery) Where(e *Expression) *DeleteQuery {
-	q.stmt.addWhere(e)
+	q.stmt.AddWhere(e)
 	return q
 }
 
@@ -69,7 +69,7 @@ func Delete(t *Table) *DeleteQuery {
 		dialect: t.meta.dialect,
 		format:  defaultFormatOptions,
 	}
-	stmt := &deleteStatement{
+	stmt := &DeleteStatement{
 		table: t,
 	}
 	return &DeleteQuery{

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -13,12 +13,12 @@ import (
 
 // DELETE FROM <table> WHERE <predicates>
 
-type deleteStatement struct {
+type DeleteStatement struct {
 	table *Table
-	where *whereClause
+	where *WhereClause
 }
 
-func (s *deleteStatement) ArgCount() int {
+func (s *DeleteStatement) ArgCount() int {
 	argc := 0
 	if s.where != nil {
 		argc += s.where.ArgCount()
@@ -26,7 +26,7 @@ func (s *deleteStatement) ArgCount() int {
 	return argc
 }
 
-func (s *deleteStatement) Size(scanner types.Scanner) int {
+func (s *DeleteStatement) Size(scanner types.Scanner) int {
 	size := len(grammar.Symbols[grammar.SYM_DELETE]) + len(s.table.name)
 	if s.where != nil {
 		size += s.where.Size(scanner)
@@ -34,7 +34,7 @@ func (s *deleteStatement) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (s *deleteStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (s *DeleteStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_DELETE])
 	// We don't add any table alias when outputting the table identifier
@@ -45,9 +45,9 @@ func (s *deleteStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	return bw
 }
 
-func (s *deleteStatement) addWhere(e *Expression) *deleteStatement {
+func (s *DeleteStatement) AddWhere(e *Expression) *DeleteStatement {
 	if s.where == nil {
-		s.where = &whereClause{filters: make([]*Expression, 0)}
+		s.where = &WhereClause{filters: make([]*Expression, 0)}
 	}
 	s.where.filters = append(s.where.filters, e)
 	return s

--- a/delete_statement_test.go
+++ b/delete_statement_test.go
@@ -21,22 +21,22 @@ func TestDeleteStatement(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *deleteStatement
+		s     *DeleteStatement
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "DELETE no WHERE",
-			s: &deleteStatement{
+			s: &DeleteStatement{
 				table: users,
 			},
 			qs: "DELETE FROM users",
 		},
 		{
 			name: "DELETE simple WHERE",
-			s: &deleteStatement{
+			s: &DeleteStatement{
 				table: users,
-				where: &whereClause{
+				where: &WhereClause{
 					filters: []*Expression{
 						Equal(colUserName, "foo"),
 					},

--- a/delete_statement_test.go
+++ b/delete_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,13 +53,13 @@ func TestDeleteStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.s.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/derived_test.go
+++ b/derived_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type derivedTest struct {
-	c     *derivedTable
+	c     *DerivedTable
 	qs    string
 	qargs []interface{}
 }
@@ -28,8 +28,8 @@ func TestDerived(t *testing.T) {
 	tests := []derivedTest{
 		// Simple one-column sub-SELECT
 		derivedTest{
-			c: &derivedTable{
-				from: &selectStatement{
+			c: &DerivedTable{
+				from: &SelectStatement{
 					projs: []types.Projection{
 						colUserName,
 					},

--- a/derived_test.go
+++ b/derived_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -44,7 +45,7 @@ func TestDerived(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.Size(defaultScanner)
+		s := test.c.Size(scanner.DefaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -52,7 +53,7 @@ func TestDerived(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/expression_test.go
+++ b/expression_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -129,13 +130,13 @@ func TestExpressions(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.c.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/format_test.go
+++ b/format_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -49,7 +50,7 @@ func TestFormatOptions(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		scanner *sqlScanner
+		scanner types.Scanner
 		s       *SelectStatement
 		qs      string
 		qargs   []interface{}
@@ -62,12 +63,11 @@ func TestFormatOptions(t *testing.T) {
 		},
 		{
 			name: "newline clause separator ",
-			scanner: &sqlScanner{
-				dialect: types.DIALECT_MYSQL,
-				format: &types.FormatOptions{
+			scanner: scanner.New(types.DIALECT_MYSQL).WithFormatOptions(
+				&types.FormatOptions{
 					SeparateClauseWith: "\n",
 				},
-			},
+			),
 			s: stmt,
 			qs: `SELECT articles.id, users.name AS author
 FROM articles
@@ -80,13 +80,12 @@ LIMIT ?`,
 		},
 		{
 			name: "newline clause separator with prefix newline",
-			scanner: &sqlScanner{
-				dialect: types.DIALECT_MYSQL,
-				format: &types.FormatOptions{
+			scanner: scanner.New(types.DIALECT_MYSQL).WithFormatOptions(
+				&types.FormatOptions{
 					SeparateClauseWith: "\n",
 					PrefixWith:         "\n",
 				},
-			},
+			),
 			s: stmt,
 			qs: `
 SELECT articles.id, users.name AS author
@@ -100,13 +99,13 @@ LIMIT ?`,
 		},
 	}
 	for _, test := range tests {
-		scanner := test.scanner
-		if scanner == nil {
-			scanner = defaultScanner
+		sc := test.scanner
+		if sc == nil {
+			sc = scanner.DefaultScanner
 		}
 		sel := &SelectQuery{
 			sel:     test.s,
-			scanner: scanner,
+			scanner: sc,
 		}
 		qs, qargs := sel.StringArgs()
 		assert.Equal(qs, test.qs)

--- a/format_test.go
+++ b/format_test.go
@@ -23,34 +23,34 @@ func TestFormatOptions(t *testing.T) {
 	colArticleId := articles.C("id")
 	colArticleAuthor := articles.C("author")
 
-	stmt := &selectStatement{
+	stmt := &SelectStatement{
 		selections: []types.Selection{articles},
 		projs:      []types.Projection{colArticleId, colUserName.As("author")},
-		joins: []*joinClause{
-			&joinClause{
+		joins: []*JoinClause{
+			&JoinClause{
 				left:  articles,
 				right: users,
 				on:    Equal(colArticleAuthor, colUserId),
 			},
 		},
-		where: &whereClause{
+		where: &WhereClause{
 			filters: []*Expression{
 				Equal(colUserName, "foo"),
 			},
 		},
-		groupBy: &groupByClause{
+		groupBy: &GroupByClause{
 			cols: []types.Projection{colUserName},
 		},
-		orderBy: &orderByClause{
-			scols: []*sortColumn{colUserName.Desc()},
+		orderBy: &OrderByClause{
+			scols: []*SortColumn{colUserName.Desc()},
 		},
-		limit: &limitClause{limit: 10},
+		limit: &LimitClause{limit: 10},
 	}
 
 	tests := []struct {
 		name    string
 		scanner *sqlScanner
-		s       *selectStatement
+		s       *SelectStatement
 		qs      string
 		qargs   []interface{}
 	}{

--- a/function_test.go
+++ b/function_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -198,17 +199,15 @@ func TestFunctions(t *testing.T) {
 
 		// Test each SQL dialect output
 		for dialect, qs := range test.qs {
-			scanner := &sqlScanner{
-				dialect: dialect,
-			}
+			sc := scanner.New(dialect)
 			expLen := len(qs)
-			size := test.c.Size(scanner)
-			size += interpolationLength(dialect, argc)
+			size := test.c.Size(sc)
+			size += scanner.InterpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			curArg := 0
-			written := test.c.Scan(scanner, b, test.qargs, &curArg)
+			written := test.c.Scan(sc, b, test.qargs, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/hashicorp/hcl v1.0.0
 	github.com/lib/pq v1.10.2
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/group_by.go
+++ b/group_by.go
@@ -10,16 +10,16 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type groupByClause struct {
+type GroupByClause struct {
 	cols []types.Projection
 }
 
-func (gb *groupByClause) ArgCount() int {
+func (gb *GroupByClause) ArgCount() int {
 	argc := 0
 	return argc
 }
 
-func (gb *groupByClause) Size(scanner types.Scanner) int {
+func (gb *GroupByClause) Size(scanner types.Scanner) int {
 	size := 0
 	size += len(scanner.FormatOptions().SeparateClauseWith)
 	size += len(grammar.Symbols[grammar.SYM_GROUP_BY])
@@ -32,7 +32,7 @@ func (gb *groupByClause) Size(scanner types.Scanner) int {
 	return size + (len(grammar.Symbols[grammar.SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (gb *groupByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (gb *GroupByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_GROUP_BY])

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -51,7 +52,7 @@ func TestGroupByClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.Size(defaultScanner)
+		s := test.c.Size(scanner.DefaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -59,7 +60,7 @@ func TestGroupByClause(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/group_by_test.go
+++ b/group_by_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type groupByClauseTest struct {
-	c     *groupByClause
+type GroupByClauseTest struct {
+	c     *GroupByClause
 	qs    string
 	qargs []interface{}
 }
@@ -26,24 +26,24 @@ func TestGroupByClause(t *testing.T) {
 	colUserId := users.C("id")
 	colUserName := users.C("name")
 
-	tests := []groupByClauseTest{
+	tests := []GroupByClauseTest{
 		// Single column
-		groupByClauseTest{
-			c: &groupByClause{
+		GroupByClauseTest{
+			c: &GroupByClause{
 				cols: []types.Projection{colUserName},
 			},
 			qs: " GROUP BY users.name",
 		},
 		// Multiple columns
-		groupByClauseTest{
-			c: &groupByClause{
+		GroupByClauseTest{
+			c: &GroupByClause{
 				cols: []types.Projection{colUserName, colUserId},
 			},
 			qs: " GROUP BY users.name, users.id",
 		},
 		// Aliased column should NOT output alias in GROUP BY
-		groupByClauseTest{
-			c: &groupByClause{
+		GroupByClauseTest{
+			c: &GroupByClause{
 				cols: []types.Projection{colUserName.As("user_name")},
 			},
 			qs: " GROUP BY users.name",

--- a/having.go
+++ b/having.go
@@ -10,11 +10,11 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type havingClause struct {
+type HavingClause struct {
 	conditions []*Expression
 }
 
-func (c *havingClause) ArgCount() int {
+func (c *HavingClause) ArgCount() int {
 	argc := 0
 	for _, condition := range c.conditions {
 		argc += condition.ArgCount()
@@ -22,7 +22,7 @@ func (c *havingClause) ArgCount() int {
 	return argc
 }
 
-func (c *havingClause) Size(scanner types.Scanner) int {
+func (c *HavingClause) Size(scanner types.Scanner) int {
 	size := 0
 	nconditions := len(c.conditions)
 	if nconditions > 0 {
@@ -36,7 +36,7 @@ func (c *havingClause) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (c *havingClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (c *HavingClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if len(c.conditions) > 0 {
 		bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)

--- a/having_test.go
+++ b/having_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -118,13 +119,13 @@ func TestHavingClause(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.c.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/having_test.go
+++ b/having_test.go
@@ -22,18 +22,18 @@ func TestHavingClause(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		c     *havingClause
+		c     *HavingClause
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "Empty HAVING clause",
-			c:    &havingClause{},
+			c:    &HavingClause{},
 			qs:   "",
 		},
 		{
 			name: "Single expression",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					Equal(colUserName, "foo"),
 				},
@@ -43,7 +43,7 @@ func TestHavingClause(t *testing.T) {
 		},
 		{
 			name: "AND expression",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					And(
 						NotEqual(colUserName, "foo"),
@@ -56,7 +56,7 @@ func TestHavingClause(t *testing.T) {
 		},
 		{
 			name: "Multiple unary expressions should be AND'd together",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					NotEqual(colUserName, "foo"),
 					NotEqual(colUserName, "bar"),
@@ -67,7 +67,7 @@ func TestHavingClause(t *testing.T) {
 		},
 		{
 			name: "OR expression",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					Or(
 						Equal(colUserName, "foo"),
@@ -80,7 +80,7 @@ func TestHavingClause(t *testing.T) {
 		},
 		{
 			name: "OR and another unary expression",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					Or(
 						Equal(colUserName, "foo"),
@@ -94,7 +94,7 @@ func TestHavingClause(t *testing.T) {
 		},
 		{
 			name: "Two AND expressions OR'd together",
-			c: &havingClause{
+			c: &HavingClause{
 				conditions: []*Expression{
 					Or(
 						And(

--- a/insert.go
+++ b/insert.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"errors"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -78,10 +79,7 @@ func Insert(t *Table, values map[string]interface{}) *InsertQuery {
 		x++
 	}
 
-	scanner := &sqlScanner{
-		dialect: t.meta.dialect,
-		format:  defaultFormatOptions,
-	}
+	scanner := scanner.New(t.meta.dialect)
 	stmt := &insertStatement{
 		table:   t,
 		columns: cols,

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -7,6 +7,7 @@ package sqlb
 
 import (
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -59,7 +60,7 @@ func (s *insertStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	}
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_VALUES])
 	for x, v := range s.values {
-		bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
+		bw += pkgscanner.ScanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 		args[*curArg] = v
 		*curArg++
 		if x != (ncols - 1) {

--- a/insert_statement_test.go
+++ b/insert_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,13 +64,13 @@ func TestInsertStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.s.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/join.go
+++ b/join.go
@@ -10,22 +10,22 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type joinType int
+type JoinType int
 
 const (
-	JOIN_INNER joinType = iota
+	JOIN_INNER JoinType = iota
 	JOIN_OUTER
 	JOIN_CROSS
 )
 
-type joinClause struct {
-	joinType joinType
+type JoinClause struct {
+	JoinType JoinType
 	left     types.Selection
 	right    types.Selection
 	on       *Expression
 }
 
-func (j *joinClause) ArgCount() int {
+func (j *JoinClause) ArgCount() int {
 	ac := 0
 	if j.on != nil {
 		ac = j.on.ArgCount()
@@ -33,10 +33,10 @@ func (j *joinClause) ArgCount() int {
 	return ac + j.left.ArgCount() + j.right.ArgCount()
 }
 
-func (j *joinClause) Size(scanner types.Scanner) int {
+func (j *JoinClause) Size(scanner types.Scanner) int {
 	size := 0
 	size += len(scanner.FormatOptions().SeparateClauseWith)
-	switch j.joinType {
+	switch j.JoinType {
 	case JOIN_INNER:
 		size += len(grammar.Symbols[grammar.SYM_JOIN])
 	case JOIN_OUTER:
@@ -52,10 +52,10 @@ func (j *joinClause) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (j *joinClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (j *JoinClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
-	switch j.joinType {
+	switch j.JoinType {
 	case JOIN_INNER:
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_JOIN])
 	case JOIN_OUTER:
@@ -71,19 +71,19 @@ func (j *joinClause) Scan(scanner types.Scanner, b []byte, args []interface{}, c
 	return bw
 }
 
-func Join(left types.Selection, right types.Selection, on *Expression) *joinClause {
-	return &joinClause{left: left, right: right, on: on}
+func Join(left types.Selection, right types.Selection, on *Expression) *JoinClause {
+	return &JoinClause{left: left, right: right, on: on}
 }
 
-func OuterJoin(left types.Selection, right types.Selection, on *Expression) *joinClause {
-	return &joinClause{
-		joinType: JOIN_OUTER,
+func OuterJoin(left types.Selection, right types.Selection, on *Expression) *JoinClause {
+	return &JoinClause{
+		JoinType: JOIN_OUTER,
 		left:     left,
 		right:    right,
 		on:       on,
 	}
 }
 
-func CrossJoin(left types.Selection, right types.Selection) *joinClause {
-	return &joinClause{joinType: JOIN_CROSS, left: left, right: right}
+func CrossJoin(left types.Selection, right types.Selection) *JoinClause {
+	return &JoinClause{JoinType: JOIN_CROSS, left: left, right: right}
 }

--- a/join_test.go
+++ b/join_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -104,7 +105,7 @@ func TestJoinClause(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.Size(defaultScanner)
+		s := test.c.Size(scanner.DefaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -112,7 +113,7 @@ func TestJoinClause(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/join_test.go
+++ b/join_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type joinClauseTest struct {
-	c     *joinClause
+type JoinClauseTest struct {
+	c     *JoinClause
 	qs    string
 	qargs []interface{}
 }
@@ -29,25 +29,25 @@ func TestJoinClause(t *testing.T) {
 	auCond := Equal(colArticleAuthor, colUserId)
 	uaCond := Equal(colUserId, colArticleAuthor)
 
-	tests := []joinClauseTest{
+	tests := []JoinClauseTest{
 		// articles to users table defs
-		joinClauseTest{
+		JoinClauseTest{
 			c:  Join(articles, users, auCond),
 			qs: " JOIN users ON articles.author = users.id",
 		},
 		// users to articles table defs
-		joinClauseTest{
+		JoinClauseTest{
 			c:  Join(users, articles, uaCond),
 			qs: " JOIN articles ON users.id = articles.author",
 		},
 		// articles to users tables
-		joinClauseTest{
+		JoinClauseTest{
 			c:  Join(articles, users, auCond),
 			qs: " JOIN users ON articles.author = users.id",
 		},
 		// join an aliased table to non-aliased table
-		joinClauseTest{
-			c: &joinClause{
+		JoinClauseTest{
+			c: &JoinClause{
 				left:  articles.As("a"),
 				right: users,
 				on:    Equal(articles.As("a").C("author"), colUserId),
@@ -55,8 +55,8 @@ func TestJoinClause(t *testing.T) {
 			qs: " JOIN users ON a.author = users.id",
 		},
 		// join a non-aliased table to aliased table
-		joinClauseTest{
-			c: &joinClause{
+		JoinClauseTest{
+			c: &JoinClause{
 				left:  articles,
 				right: users.As("u"),
 				on:    Equal(colArticleAuthor, users.As("u").C("id")),
@@ -64,8 +64,8 @@ func TestJoinClause(t *testing.T) {
 			qs: " JOIN users AS u ON articles.author = u.id",
 		},
 		// aliased projections should not include "AS alias" in output
-		joinClauseTest{
-			c: &joinClause{
+		JoinClauseTest{
+			c: &JoinClause{
 				left:  articles,
 				right: users,
 				on:    Equal(colArticleAuthor, colUserId.As("user_id")),
@@ -73,9 +73,9 @@ func TestJoinClause(t *testing.T) {
 			qs: " JOIN users ON articles.author = users.id",
 		},
 		// simple outer join manual construction
-		joinClauseTest{
-			c: &joinClause{
-				joinType: JOIN_OUTER,
+		JoinClauseTest{
+			c: &JoinClause{
+				JoinType: JOIN_OUTER,
 				left:     articles,
 				right:    users,
 				on:       Equal(colArticleAuthor, colUserId),
@@ -83,21 +83,21 @@ func TestJoinClause(t *testing.T) {
 			qs: " LEFT JOIN users ON articles.author = users.id",
 		},
 		// OuterJoin() function
-		joinClauseTest{
+		JoinClauseTest{
 			c:  OuterJoin(articles, users, Equal(colArticleAuthor, colUserId)),
 			qs: " LEFT JOIN users ON articles.author = users.id",
 		},
 		// cross join manual construction
-		joinClauseTest{
-			c: &joinClause{
-				joinType: JOIN_CROSS,
+		JoinClauseTest{
+			c: &JoinClause{
+				JoinType: JOIN_CROSS,
 				left:     articles,
 				right:    users,
 			},
 			qs: " CROSS JOIN users",
 		},
 		// CrossJoin() function
-		joinClauseTest{
+		JoinClauseTest{
 			c:  CrossJoin(articles, users),
 			qs: " CROSS JOIN users",
 		},

--- a/limit.go
+++ b/limit.go
@@ -10,19 +10,19 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type limitClause struct {
+type LimitClause struct {
 	limit  int
 	offset *int
 }
 
-func (lc *limitClause) ArgCount() int {
+func (lc *LimitClause) ArgCount() int {
 	if lc.offset == nil {
 		return 1
 	}
 	return 2
 }
 
-func (lc *limitClause) Size(scanner types.Scanner) int {
+func (lc *LimitClause) Size(scanner types.Scanner) int {
 	// Due to dialect handling, we do not include the length of interpolation
 	// markers for query parameters. This is calculated separately by the
 	// top-level scanning struct before malloc'ing the buffer to inject the SQL
@@ -36,7 +36,7 @@ func (lc *limitClause) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (lc *limitClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (lc *LimitClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_LIMIT])

--- a/limit.go
+++ b/limit.go
@@ -7,6 +7,7 @@ package sqlb
 
 import (
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -40,12 +41,12 @@ func (lc *LimitClause) Scan(scanner types.Scanner, b []byte, args []interface{},
 	bw := 0
 	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_LIMIT])
-	bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
+	bw += pkgscanner.ScanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 	args[*curArg] = lc.limit
 	*curArg++
 	if lc.offset != nil {
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_OFFSET])
-		bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
+		bw += pkgscanner.ScanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 		args[*curArg] = *lc.offset
 		*curArg++
 	}

--- a/limit_test.go
+++ b/limit_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,15 +26,15 @@ func TestLimitClause(t *testing.T) {
 	argc := lc.ArgCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.Size(defaultScanner)
-	size += interpolationLength(types.DIALECT_MYSQL, argc)
+	size := lc.Size(scanner.DefaultScanner)
+	size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
 
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.Scan(defaultScanner, b, args, &curArg)
+	written := lc.Scan(scanner.DefaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))
@@ -55,15 +56,15 @@ func TestLimitClauseWithOffset(t *testing.T) {
 	argc := lc.ArgCount()
 	assert.Equal(expArgCount, argc)
 
-	size := lc.Size(defaultScanner)
-	size += interpolationLength(types.DIALECT_MYSQL, argc)
+	size := lc.Size(scanner.DefaultScanner)
+	size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 	expLen := len(exp)
 	assert.Equal(expLen, size)
 
 	args := make([]interface{}, expArgCount)
 	b := make([]byte, size)
 	curArg := 0
-	written := lc.Scan(defaultScanner, b, args, &curArg)
+	written := lc.Scan(scanner.DefaultScanner, b, args, &curArg)
 
 	assert.Equal(size, written)
 	assert.Equal(exp, string(b))

--- a/limit_test.go
+++ b/limit_test.go
@@ -15,7 +15,7 @@ import (
 func TestLimitClause(t *testing.T) {
 	assert := assert.New(t)
 
-	lc := &limitClause{
+	lc := &LimitClause{
 		limit: 20,
 	}
 
@@ -43,7 +43,7 @@ func TestLimitClause(t *testing.T) {
 func TestLimitClauseWithOffset(t *testing.T) {
 	assert := assert.New(t)
 
-	lc := &limitClause{
+	lc := &LimitClause{
 		limit: 20,
 	}
 	offset := 10

--- a/list_test.go
+++ b/list_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,11 +24,11 @@ func TestListSingle(t *testing.T) {
 
 	exp := "users.name"
 	expLen := len(exp)
-	s := cl.Size(defaultScanner)
+	s := cl.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.Scan(defaultScanner, b, nil, nil)
+	written := cl.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -45,11 +46,11 @@ func TestListMulti(t *testing.T) {
 
 	exp := "users.id, users.name"
 	expLen := len(exp)
-	s := cl.Size(defaultScanner)
+	s := cl.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := cl.Scan(defaultScanner, b, nil, nil)
+	written := cl.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/order_by.go
+++ b/order_by.go
@@ -10,16 +10,16 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type sortColumn struct {
+type SortColumn struct {
 	p    types.Projection
 	desc bool
 }
 
-func (sc *sortColumn) ArgCount() int {
+func (sc *SortColumn) ArgCount() int {
 	return sc.p.ArgCount()
 }
 
-func (sc *sortColumn) Size(scanner types.Scanner) int {
+func (sc *SortColumn) Size(scanner types.Scanner) int {
 	reset := sc.p.DisableAliasScan()
 	defer reset()
 	size := sc.p.Size(scanner)
@@ -29,7 +29,7 @@ func (sc *sortColumn) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (sc *sortColumn) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (sc *SortColumn) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	reset := sc.p.DisableAliasScan()
 	defer reset()
 	bw := 0
@@ -40,16 +40,16 @@ func (sc *sortColumn) Scan(scanner types.Scanner, b []byte, args []interface{}, 
 	return bw
 }
 
-type orderByClause struct {
-	scols []*sortColumn
+type OrderByClause struct {
+	scols []*SortColumn
 }
 
-func (ob *orderByClause) ArgCount() int {
+func (ob *OrderByClause) ArgCount() int {
 	argc := 0
 	return argc
 }
 
-func (ob *orderByClause) Size(scanner types.Scanner) int {
+func (ob *OrderByClause) Size(scanner types.Scanner) int {
 	size := 0
 	size += len(scanner.FormatOptions().SeparateClauseWith)
 	size += len(grammar.Symbols[grammar.SYM_ORDER_BY])
@@ -60,7 +60,7 @@ func (ob *orderByClause) Size(scanner types.Scanner) int {
 	return size + (len(grammar.Symbols[grammar.SYM_COMMA_WS]) * (ncols - 1)) // the commas...
 }
 
-func (ob *orderByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (ob *OrderByClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_ORDER_BY])
@@ -74,18 +74,18 @@ func (ob *orderByClause) Scan(scanner types.Scanner, b []byte, args []interface{
 	return bw
 }
 
-func (c *Column) Desc() *sortColumn {
-	return &sortColumn{p: c, desc: true}
+func (c *Column) Desc() *SortColumn {
+	return &SortColumn{p: c, desc: true}
 }
 
-func (c *Column) Asc() *sortColumn {
-	return &sortColumn{p: c}
+func (c *Column) Asc() *SortColumn {
+	return &SortColumn{p: c}
 }
 
-func (f *sqlFunc) Desc() *sortColumn {
-	return &sortColumn{p: f, desc: true}
+func (f *sqlFunc) Desc() *SortColumn {
+	return &SortColumn{p: f, desc: true}
 }
 
-func (f *sqlFunc) Asc() *sortColumn {
-	return &sortColumn{p: f}
+func (f *sqlFunc) Asc() *SortColumn {
+	return &SortColumn{p: f}
 }

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type orderByTest struct {
-	c     *orderByClause
+	c     *OrderByClause
 	qs    string
 	qargs []interface{}
 }
@@ -28,36 +28,36 @@ func TestOrderBy(t *testing.T) {
 	tests := []orderByTest{
 		// column asc
 		orderByTest{
-			c: &orderByClause{
-				scols: []*sortColumn{colUserName.Asc()},
+			c: &OrderByClause{
+				scols: []*SortColumn{colUserName.Asc()},
 			},
 			qs: " ORDER BY users.name",
 		},
 		// column desc
 		orderByTest{
-			c: &orderByClause{
-				scols: []*sortColumn{colUserName.Desc()},
+			c: &OrderByClause{
+				scols: []*SortColumn{colUserName.Desc()},
 			},
 			qs: " ORDER BY users.name DESC",
 		},
 		// Aliased column should NOT output alias in ORDER BY
 		orderByTest{
-			c: &orderByClause{
-				scols: []*sortColumn{colUserName.As("user_name").Desc()},
+			c: &OrderByClause{
+				scols: []*SortColumn{colUserName.As("user_name").Desc()},
 			},
 			qs: " ORDER BY users.name DESC",
 		},
 		// multi column mixed
 		orderByTest{
-			c: &orderByClause{
-				scols: []*sortColumn{colUserName.Asc(), colUserId.Desc()},
+			c: &OrderByClause{
+				scols: []*SortColumn{colUserName.Asc(), colUserId.Desc()},
 			},
 			qs: " ORDER BY users.name, users.id DESC",
 		},
 		// sort by a function
 		orderByTest{
-			c: &orderByClause{
-				scols: []*sortColumn{Count(users).Desc()},
+			c: &OrderByClause{
+				scols: []*SortColumn{Count(users).Desc()},
 			},
 			qs: " ORDER BY COUNT(*) DESC",
 		},

--- a/order_by_test.go
+++ b/order_by_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,7 +65,7 @@ func TestOrderBy(t *testing.T) {
 	}
 	for _, test := range tests {
 		expLen := len(test.qs)
-		s := test.c.Size(defaultScanner)
+		s := test.c.Size(scanner.DefaultScanner)
 		assert.Equal(expLen, s)
 
 		expArgc := len(test.qargs)
@@ -72,7 +73,7 @@ func TestOrderBy(t *testing.T) {
 
 		b := make([]byte, s)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, s)
 		assert.Equal(test.qs, string(b))

--- a/pkg/scanner/default.go
+++ b/pkg/scanner/default.go
@@ -1,0 +1,24 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package scanner
+
+import (
+	"github.com/jaypipes/sqlb/pkg/types"
+)
+
+// DefaultFormatOptions is the set of formatting options used if not specified
+// by the user
+var DefaultFormatOptions = &types.FormatOptions{
+	SeparateClauseWith: " ",
+	PrefixWith:         "",
+}
+
+// DefaultScanner is the default scanner used if not specified by the user
+var DefaultScanner = &sqlScanner{
+	dialect: types.DIALECT_MYSQL,
+	format:  DefaultFormatOptions,
+}

--- a/pkg/scanner/interpolation_marker.go
+++ b/pkg/scanner/interpolation_marker.go
@@ -3,7 +3,8 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
-package sqlb
+
+package scanner
 
 import (
 	"strconv"
@@ -12,12 +13,13 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-// Returns the total length of the characters representing interpolation
-// markers for query parameters. Different SQL dialects use different character
-// sequences for marking query parameters during query preparation. For
-// instance, MySQL and SQLite use the ? character. PostgreSQL uses a numbered
-// $N schema with N starting at 1, SQL Server uses a :N scheme, etc.
-func interpolationLength(dialect types.Dialect, argc int) int {
+// InterpolationLength returns the total length of the characters representing
+// interpolation markers for query parameters. Different SQL dialects use
+// different character sequences for marking query parameters during query
+// preparation. For instance, MySQL and SQLite use the ? character. PostgreSQL
+// uses a numbered $N schema with N starting at 1, SQL Server uses a :N scheme,
+// etc.
+func InterpolationLength(dialect types.Dialect, argc int) int {
 	if dialect == types.DIALECT_POSTGRESQL {
 		// $ character for each interpolated parameter plus ones digit of
 		// number
@@ -39,7 +41,9 @@ func interpolationLength(dialect types.Dialect, argc int) int {
 	return argc // Single question mark used as interpolation marker
 }
 
-func scanInterpolationMarker(dialect types.Dialect, b []byte, position int) int {
+// ScanInterpolationMarker adds an interpolation marker of the specified
+// dialect and position into the supplied bytestream
+func ScanInterpolationMarker(dialect types.Dialect, b []byte, position int) int {
 	if dialect == types.DIALECT_POSTGRESQL {
 		bw := copy(b, grammar.Symbols[grammar.SYM_DOLLAR])
 		bw += copy(b[bw:], []byte(strconv.Itoa(position+1)))

--- a/pkg/scanner/new.go
+++ b/pkg/scanner/new.go
@@ -4,24 +4,16 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package sqlb
+package scanner
 
 import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-var defaultFormatOptions = &types.FormatOptions{
-	SeparateClauseWith: " ",
-	PrefixWith:         "",
-}
-
-var defaultScanner = &sqlScanner{
-	dialect: types.DIALECT_MYSQL,
-	format:  defaultFormatOptions,
-}
-
 // The struct that holds information about the formatting and dialect of the
 // output SQL that sqlb writes to the output buffer
+//
+// implements pkg/types.Scanner
 type sqlScanner struct {
 	dialect types.Dialect
 	format  *types.FormatOptions
@@ -44,7 +36,7 @@ func (s *sqlScanner) Size(elements ...types.Element) *types.ElementSizes {
 		argc += el.ArgCount()
 		buflen += el.Size(s)
 	}
-	buflen += interpolationLength(s.dialect, argc)
+	buflen += InterpolationLength(s.dialect, argc)
 	buflen += len(s.format.PrefixWith)
 
 	return &types.ElementSizes{
@@ -57,6 +49,24 @@ func (s *sqlScanner) Dialect() types.Dialect {
 	return s.dialect
 }
 
+func (s *sqlScanner) WithDialect(dialect types.Dialect) types.Scanner {
+	s.dialect = dialect
+	return s
+}
+
 func (s *sqlScanner) FormatOptions() *types.FormatOptions {
 	return s.format
+}
+
+func (s *sqlScanner) WithFormatOptions(opts *types.FormatOptions) types.Scanner {
+	s.format = opts
+	return s
+}
+
+// New returns a scanner for the supplied dialect
+func New(dialect types.Dialect) types.Scanner {
+	return &sqlScanner{
+		dialect: dialect,
+		format:  DefaultFormatOptions,
+	}
 }

--- a/pkg/types/scanner.go
+++ b/pkg/types/scanner.go
@@ -22,5 +22,7 @@ type Scanner interface {
 	Scan([]byte, []interface{}, ...Scannable)
 	Size(...Element) *ElementSizes
 	Dialect() Dialect
+	WithDialect(Dialect) Scanner
 	FormatOptions() *FormatOptions
+	WithFormatOptions(*FormatOptions) Scanner
 }

--- a/select.go
+++ b/select.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -22,7 +23,7 @@ type SelectQuery struct {
 	b       []byte
 	args    []interface{}
 	sel     *SelectStatement
-	scanner *sqlScanner
+	scanner types.Scanner
 }
 
 func (q *SelectQuery) IsValid() bool {
@@ -260,10 +261,7 @@ func (q *SelectQuery) doJoin(
 }
 
 func Select(items ...interface{}) *SelectQuery {
-	scanner := &sqlScanner{
-		dialect: types.DIALECT_UNKNOWN,
-		format:  defaultFormatOptions,
-	}
+	scanner := scanner.New(types.DIALECT_UNKNOWN)
 	sq := &SelectQuery{
 		scanner: scanner,
 	}
@@ -329,13 +327,13 @@ func Select(items ...interface{}) *SelectQuery {
 		case *Column:
 			v := item.(*Column)
 			// Set scanner's dialect based on supplied meta's dialect
-			sq.scanner.dialect = v.tbl.meta.dialect
+			sq.scanner.WithDialect(v.tbl.meta.dialect)
 			sel.projs = append(sel.projs, v)
 			selectionMap[v.tbl] = true
 		case *Table:
 			v := item.(*Table)
 			// Set scanner's dialect based on supplied meta's dialect
-			sq.scanner.dialect = v.meta.dialect
+			sq.scanner.WithDialect(v.meta.dialect)
 			for _, c := range v.Projections() {
 				addToProjections(sel, c)
 			}

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -30,13 +30,13 @@ func TestSelectClause(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *selectStatement
+		s     *SelectStatement
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "A literal value",
-			s: &selectStatement{
+			s: &SelectStatement{
 				projs: []types.Projection{&value{val: 1}},
 			},
 			qs:    "SELECT ?",
@@ -44,7 +44,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "A literal value aliased",
-			s: &selectStatement{
+			s: &SelectStatement{
 				projs: []types.Projection{
 					&value{alias: "foo", val: 1},
 				},
@@ -54,7 +54,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Two literal values",
-			s: &selectStatement{
+			s: &SelectStatement{
 				projs: []types.Projection{
 					&value{val: 1},
 					&value{val: 1},
@@ -65,7 +65,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and column",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
 			},
@@ -73,7 +73,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "aliased Table and Column",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users.As("u")},
 				projs: []types.Projection{
 					users.As("u").C("name"),
@@ -83,7 +83,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and multiple Column",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserId, colUserName},
 			},
@@ -91,10 +91,10 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple WHERE",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
-				where: &whereClause{
+				where: &WhereClause{
 					filters: []*Expression{
 						Equal(colUserName, "foo"),
 					},
@@ -105,31 +105,31 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple LIMIT",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
-				limit:      &limitClause{limit: 10},
+				limit:      &LimitClause{limit: 10},
 			},
 			qs:    "SELECT users.name FROM users LIMIT ?",
 			qargs: []interface{}{10},
 		},
 		{
 			name: "Simple ORDER BY",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
-				orderBy: &orderByClause{
-					scols: []*sortColumn{colUserName.Desc()},
+				orderBy: &OrderByClause{
+					scols: []*SortColumn{colUserName.Desc()},
 				},
 			},
 			qs: "SELECT users.name FROM users ORDER BY users.name DESC",
 		},
 		{
 			name: "Simple GROUP BY",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
-				groupBy: &groupByClause{
+				groupBy: &GroupByClause{
 					cols: []types.Projection{colUserName},
 				},
 			},
@@ -137,27 +137,27 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "GROUP BY, ORDER BY and LIMIT",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{colUserName},
-				groupBy: &groupByClause{
+				groupBy: &GroupByClause{
 					cols: []types.Projection{colUserName},
 				},
-				orderBy: &orderByClause{
-					scols: []*sortColumn{colUserName.Desc()},
+				orderBy: &OrderByClause{
+					scols: []*SortColumn{colUserName.Desc()},
 				},
-				limit: &limitClause{limit: 10},
+				limit: &LimitClause{limit: 10},
 			},
 			qs:    "SELECT users.name FROM users GROUP BY users.name ORDER BY users.name DESC LIMIT ?",
 			qargs: []interface{}{10},
 		},
 		{
 			name: "Single JOIN",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{articles},
 				projs:      []types.Projection{colArticleId, colUserName.As("author")},
-				joins: []*joinClause{
-					&joinClause{
+				joins: []*JoinClause{
+					&JoinClause{
 						left:  articles,
 						right: users,
 						on:    Equal(colArticleAuthor, colUserId),
@@ -168,16 +168,16 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Multiple JOINs",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{articles},
 				projs:      []types.Projection{colArticleId, colUserName.As("author"), colArticleStateName.As("state")},
-				joins: []*joinClause{
-					&joinClause{
+				joins: []*JoinClause{
+					&JoinClause{
 						left:  articles,
 						right: users,
 						on:    Equal(colArticleAuthor, colUserId),
 					},
-					&joinClause{
+					&JoinClause{
 						left:  articles,
 						right: article_states,
 						on:    Equal(colArticleState, colArticleStateId),
@@ -188,7 +188,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "COUNT(*) on a table",
-			s: &selectStatement{
+			s: &SelectStatement{
 				selections: []types.Selection{users},
 				projs:      []types.Projection{Count(users)},
 			},

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -201,13 +202,13 @@ func TestSelectClause(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.s.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/string_functions.go
+++ b/string_functions.go
@@ -7,6 +7,7 @@ package sqlb
 
 import (
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -138,7 +139,7 @@ func trimFuncScanMySQL(f *trimFunc, scanner types.Scanner, b []byte, args []inte
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRIM])
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_LEADING])
 			bw += copy(b[bw:], " ")
-			bw += scanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], " ")
@@ -152,7 +153,7 @@ func trimFuncScanMySQL(f *trimFunc, scanner types.Scanner, b []byte, args []inte
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRIM])
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRAILING])
 			bw += copy(b[bw:], " ")
-			bw += scanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], " ")
@@ -164,7 +165,7 @@ func trimFuncScanMySQL(f *trimFunc, scanner types.Scanner, b []byte, args []inte
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRIM])
 		} else {
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRIM])
-			bw += scanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_MYSQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 			bw += copy(b[bw:], " ")
@@ -219,7 +220,7 @@ func trimFuncScanPostgreSQL(f *trimFunc, scanner types.Scanner, b []byte, args [
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_LEADING])
 		if f.chars != "" {
 			bw += copy(b[bw:], " ")
-			bw += scanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 		}
@@ -231,7 +232,7 @@ func trimFuncScanPostgreSQL(f *trimFunc, scanner types.Scanner, b []byte, args [
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_TRAILING])
 		if f.chars != "" {
 			bw += copy(b[bw:], " ")
-			bw += scanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 		}
@@ -243,7 +244,7 @@ func trimFuncScanPostgreSQL(f *trimFunc, scanner types.Scanner, b []byte, args [
 		bw += trimFuncScanSubject(f, scanner, b[bw:], args, curArg)
 		if f.chars != "" {
 			bw += copy(b[bw:], grammar.Symbols[grammar.SYM_COMMA_WS])
-			bw += scanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
+			bw += pkgscanner.ScanInterpolationMarker(types.DIALECT_POSTGRESQL, b[bw:], *curArg)
 			args[*curArg] = f.chars
 			*curArg++
 		}

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -84,18 +85,16 @@ func TestTrimFunctions(t *testing.T) {
 
 		// Test each SQL dialect output
 		for dialect, qs := range test.qs {
-			scanner := &sqlScanner{
-				dialect: dialect,
-			}
+			sc := scanner.New(dialect)
 			expLen := len(qs)
-			size := test.el.Size(scanner)
-			size += interpolationLength(dialect, argc)
+			size := test.el.Size(sc)
+			size += scanner.InterpolationLength(dialect, argc)
 			assert.Equal(expLen, size)
 
 			b := make([]byte, size)
 			args := make([]interface{}, argc)
 			curArg := 0
-			written := test.el.Scan(scanner, b, args, &curArg)
+			written := test.el.Scan(sc, b, args, &curArg)
 
 			assert.Equal(written, size)
 			assert.Equal(qs, string(b))

--- a/table_test.go
+++ b/table_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -41,11 +42,11 @@ func TestTable(t *testing.T) {
 
 	exp := "users"
 	expLen := len(exp)
-	s := users.Size(defaultScanner)
+	s := users.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := users.Scan(defaultScanner, b, nil, nil)
+	written := users.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))
@@ -59,11 +60,11 @@ func TestTableAlias(t *testing.T) {
 
 	exp := "users AS u"
 	expLen := len(exp)
-	s := u.Size(defaultScanner)
+	s := u.Size(scanner.DefaultScanner)
 	assert.Equal(expLen, s)
 
 	b := make([]byte, s)
-	written := u.Scan(defaultScanner, b, nil, nil)
+	written := u.Scan(scanner.DefaultScanner, b, nil, nil)
 
 	assert.Equal(written, s)
 	assert.Equal(exp, string(b))

--- a/update.go
+++ b/update.go
@@ -19,7 +19,7 @@ type UpdateQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	stmt    *updateStatement
+	stmt    *UpdateStatement
 	scanner *sqlScanner
 }
 
@@ -56,7 +56,7 @@ func (q *UpdateQuery) StringArgs() (string, []interface{}) {
 }
 
 func (q *UpdateQuery) Where(e *Expression) *UpdateQuery {
-	q.stmt.addWhere(e)
+	q.stmt.AddWhere(e)
 	return q
 }
 
@@ -89,7 +89,7 @@ func Update(t *Table, values map[string]interface{}) *UpdateQuery {
 		dialect: t.meta.dialect,
 		format:  defaultFormatOptions,
 	}
-	stmt := &updateStatement{
+	stmt := &UpdateStatement{
 		table:   t,
 		columns: cols,
 		values:  vals,

--- a/update.go
+++ b/update.go
@@ -7,6 +7,9 @@ package sqlb
 
 import (
 	"errors"
+
+	"github.com/jaypipes/sqlb/pkg/scanner"
+	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 var (
@@ -20,7 +23,7 @@ type UpdateQuery struct {
 	b       []byte
 	args    []interface{}
 	stmt    *UpdateStatement
-	scanner *sqlScanner
+	scanner types.Scanner
 }
 
 func (q *UpdateQuery) IsValid() bool {
@@ -85,10 +88,7 @@ func Update(t *Table, values map[string]interface{}) *UpdateQuery {
 		x++
 	}
 
-	scanner := &sqlScanner{
-		dialect: t.meta.dialect,
-		format:  defaultFormatOptions,
-	}
+	scanner := scanner.New(t.meta.dialect)
 	stmt := &UpdateStatement{
 		table:   t,
 		columns: cols,

--- a/update_statement.go
+++ b/update_statement.go
@@ -7,6 +7,7 @@ package sqlb
 
 import (
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -61,7 +62,7 @@ func (s *UpdateStatement) Scan(scanner types.Scanner, b []byte, args []interface
 		// statement
 		bw += copy(b[bw:], c.name)
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_EQUAL])
-		bw += scanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
+		bw += pkgscanner.ScanInterpolationMarker(scanner.Dialect(), b[bw:], *curArg)
 		args[*curArg] = s.values[x]
 		*curArg++
 		if x != (ncols - 1) {

--- a/update_statement.go
+++ b/update_statement.go
@@ -12,14 +12,14 @@ import (
 
 // UPDATE <table> SET <column_value_list>[ WHERE <predicates>]
 
-type updateStatement struct {
+type UpdateStatement struct {
 	table   *Table
 	columns []*Column
 	values  []interface{}
-	where   *whereClause
+	where   *WhereClause
 }
 
-func (s *updateStatement) ArgCount() int {
+func (s *UpdateStatement) ArgCount() int {
 	argc := len(s.values)
 	if s.where != nil {
 		argc += s.where.ArgCount()
@@ -27,7 +27,7 @@ func (s *updateStatement) ArgCount() int {
 	return argc
 }
 
-func (s *updateStatement) Size(scanner types.Scanner) int {
+func (s *UpdateStatement) Size(scanner types.Scanner) int {
 	size := len(grammar.Symbols[grammar.SYM_UPDATE]) + len(s.table.name) + len(grammar.Symbols[grammar.SYM_SET])
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -47,7 +47,7 @@ func (s *updateStatement) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (s *updateStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (s *UpdateStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_UPDATE])
 	// We don't add any table alias when outputting the table identifier
@@ -75,9 +75,9 @@ func (s *updateStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	return bw
 }
 
-func (s *updateStatement) addWhere(e *Expression) *updateStatement {
+func (s *UpdateStatement) AddWhere(e *Expression) *UpdateStatement {
 	if s.where == nil {
-		s.where = &whereClause{filters: make([]*Expression, 0)}
+		s.where = &WhereClause{filters: make([]*Expression, 0)}
 	}
 	s.where.filters = append(s.where.filters, e)
 	return s

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -21,13 +21,13 @@ func TestUpdateStatement(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *updateStatement
+		s     *UpdateStatement
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "UPDATE no WHERE",
-			s: &updateStatement{
+			s: &UpdateStatement{
 				table:   users,
 				columns: []*Column{colUserName},
 				values:  []interface{}{"foo"},
@@ -37,11 +37,11 @@ func TestUpdateStatement(t *testing.T) {
 		},
 		{
 			name: "UPDATE simple WHERE",
-			s: &updateStatement{
+			s: &UpdateStatement{
 				table:   users,
 				columns: []*Column{colUserName},
 				values:  []interface{}{"foo"},
-				where: &whereClause{
+				where: &WhereClause{
 					filters: []*Expression{
 						Equal(colUserName, "bar"),
 					},

--- a/update_statement_test.go
+++ b/update_statement_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -57,13 +58,13 @@ func TestUpdateStatement(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.s.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.s.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.s.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.s.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))

--- a/value.go
+++ b/value.go
@@ -7,6 +7,7 @@ package sqlb
 
 import (
 	"github.com/jaypipes/sqlb/pkg/grammar"
+	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -60,7 +61,7 @@ func (v *value) Size(scanner types.Scanner) int {
 
 func (v *value) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	args[*curArg] = v.val
-	bw := scanInterpolationMarker(scanner.Dialect(), b, *curArg)
+	bw := pkgscanner.ScanInterpolationMarker(scanner.Dialect(), b, *curArg)
 	*curArg++
 	if v.alias != "" {
 		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_AS])

--- a/value_test.go
+++ b/value_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +17,7 @@ func TestValue(t *testing.T) {
 
 	v := &value{val: "foo"}
 
-	s := v.Size(defaultScanner)
+	s := v.Size(scanner.DefaultScanner)
 	// Due to dialect handling, we can't include interpolation markers in the
 	// size calculation, so size() always returns 0 for non-aliased values.
 	assert.Equal(0, s)
@@ -27,7 +28,7 @@ func TestValue(t *testing.T) {
 	args := make([]interface{}, 1)
 	b := make([]byte, 1)
 	curArg := 0
-	written := v.Scan(defaultScanner, b, args, &curArg)
+	written := v.Scan(scanner.DefaultScanner, b, args, &curArg)
 
 	exp := "?"
 	expLen := len(exp)

--- a/where.go
+++ b/where.go
@@ -10,11 +10,11 @@ import (
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-type whereClause struct {
+type WhereClause struct {
 	filters []*Expression
 }
 
-func (w *whereClause) ArgCount() int {
+func (w *WhereClause) ArgCount() int {
 	argc := 0
 	for _, filter := range w.filters {
 		argc += filter.ArgCount()
@@ -22,7 +22,7 @@ func (w *whereClause) ArgCount() int {
 	return argc
 }
 
-func (w *whereClause) Size(scanner types.Scanner) int {
+func (w *WhereClause) Size(scanner types.Scanner) int {
 	size := 0
 	nfilters := len(w.filters)
 	if nfilters > 0 {
@@ -36,7 +36,7 @@ func (w *whereClause) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (w *whereClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (w *WhereClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	if len(w.filters) > 0 {
 		bw += copy(b[bw:], scanner.FormatOptions().SeparateClauseWith)

--- a/where_test.go
+++ b/where_test.go
@@ -12,9 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type whereClauseTest struct {
-}
-
 func TestWhereClause(t *testing.T) {
 	assert := assert.New(t)
 
@@ -25,18 +22,18 @@ func TestWhereClause(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		c     *whereClause
+		c     *WhereClause
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "Empty WHERE clause",
-			c:    &whereClause{},
+			c:    &WhereClause{},
 			qs:   "",
 		},
 		{
 			name: "Single expression",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					Equal(colUserName, "foo"),
 				},
@@ -46,7 +43,7 @@ func TestWhereClause(t *testing.T) {
 		},
 		{
 			name: "AND expression",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					And(
 						NotEqual(colUserName, "foo"),
@@ -59,7 +56,7 @@ func TestWhereClause(t *testing.T) {
 		},
 		{
 			name: "Multiple unary expressions should be AND'd together",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					NotEqual(colUserName, "foo"),
 					NotEqual(colUserName, "bar"),
@@ -70,7 +67,7 @@ func TestWhereClause(t *testing.T) {
 		},
 		{
 			name: "OR expression",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					Or(
 						Equal(colUserName, "foo"),
@@ -83,7 +80,7 @@ func TestWhereClause(t *testing.T) {
 		},
 		{
 			name: "OR and another unary expression",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					Or(
 						Equal(colUserName, "foo"),
@@ -97,7 +94,7 @@ func TestWhereClause(t *testing.T) {
 		},
 		{
 			name: "Two AND expressions OR'd together",
-			c: &whereClause{
+			c: &WhereClause{
 				filters: []*Expression{
 					Or(
 						And(

--- a/where_test.go
+++ b/where_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -118,13 +119,13 @@ func TestWhereClause(t *testing.T) {
 		assert.Equal(expArgc, argc)
 
 		expLen := len(test.qs)
-		size := test.c.Size(defaultScanner)
-		size += interpolationLength(types.DIALECT_MYSQL, argc)
+		size := test.c.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
 		assert.Equal(expLen, size)
 
 		b := make([]byte, size)
 		curArg := 0
-		written := test.c.Scan(defaultScanner, b, test.qargs, &curArg)
+		written := test.c.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
 
 		assert.Equal(written, size)
 		assert.Equal(test.qs, string(b))


### PR DESCRIPTION
Two refactoring patches that prepare for the coming split of root-level
files and structs into a `pkg/grammar/clause` package.

We create a `pkg/grammar` package with our core symbols and a
`pkg/scanner` package containing the bits that process the grammar.