### PR TITLE
split out statement structs and introduce Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ func getArticles() []*Article {
     q.Limit(10)
 
     articles := make([]*Article, 0)
-    rows, err := db.Query(q.String())
+    rows, err := sqlb.Query(db, q)
     if err != nil {
         log.Fatal(err)
     }
@@ -296,8 +296,7 @@ func getArticles(numArticles int, byAuthor string) []*Articles {
     q.Limit(numArticle)
 
     articles := make([]*Article, 0)
-    qs, qargs := q.StringArgs()
-    rows, err := db.Query(qs, qargs...)
+    rows, err := sqlb.Query(db, q)
     if err != nil {
         log.Fatal(err)
     }

--- a/delete.go
+++ b/delete.go
@@ -34,28 +34,16 @@ func (q *DeleteQuery) Error() error {
 	return q.e
 }
 
-func (q *DeleteQuery) String() string {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b)
+func (q *DeleteQuery) Scan(s types.Scanner, b []byte, qargs []interface{}, idx *int) int {
+	return q.stmt.Scan(s, b, qargs, idx)
 }
 
-func (q *DeleteQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b), q.args
+func (q *DeleteQuery) ArgCount() int {
+	return q.stmt.ArgCount()
+}
+
+func (q *DeleteQuery) Size(s types.Scanner) int {
+	return q.stmt.Size(s)
 }
 
 func (q *DeleteQuery) Where(e *ast.Expression) *DeleteQuery {

--- a/delete.go
+++ b/delete.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
@@ -21,7 +22,7 @@ type DeleteQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	stmt    *ast.DeleteStatement
+	stmt    *statement.Delete
 	scanner types.Scanner
 }
 
@@ -69,11 +70,9 @@ func Delete(t *ast.TableIdentifier) *DeleteQuery {
 		return &DeleteQuery{e: ERR_DELETE_NO_TARGET}
 	}
 
-	scanner := scanner.New(t.Schema().Dialect)
-	stmt := ast.NewDeleteStatement(t, nil)
 	return &DeleteQuery{
-		stmt:    stmt,
-		scanner: scanner,
+		scanner: scanner.New(t.Schema().Dialect),
+		stmt:    statement.NewDelete(t, nil),
 	}
 }
 

--- a/delete_test.go
+++ b/delete_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +59,8 @@ func TestDeleteQuery(t *testing.T) {
 			assert.Fail(qe.Error())
 			continue
 		}
-		qs, qargs := test.q.StringArgs()
+		scan := scanner.DefaultScanner
+		qs, qargs := scan.StringArgs(test.q)
 		assert.Equal(len(test.qargs), len(qargs))
 		assert.Equal(test.qs, qs)
 	}

--- a/format_test.go
+++ b/format_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -26,7 +27,7 @@ func TestFormatOptions(t *testing.T) {
 	colArticleId := articles.C("id")
 	colArticleAuthor := articles.C("author")
 
-	stmt := ast.NewSelectStatement(
+	stmt := statement.NewSelect(
 		[]types.Projection{colArticleId, colUserName.As("author")},
 		[]types.Selection{articles},
 		[]*ast.JoinClause{
@@ -48,7 +49,7 @@ func TestFormatOptions(t *testing.T) {
 	tests := []struct {
 		name    string
 		scanner types.Scanner
-		s       *ast.SelectStatement
+		s       *statement.Select
 		qs      string
 		qargs   []interface{}
 	}{

--- a/insert.go
+++ b/insert.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jaypipes/sqlb/pkg/ast"
 	"github.com/jaypipes/sqlb/pkg/grammar/statement"
-	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
@@ -20,11 +19,8 @@ var (
 )
 
 type InsertQuery struct {
-	e       error
-	b       []byte
-	args    []interface{}
-	stmt    *statement.Insert
-	scanner types.Scanner
+	e    error
+	stmt *statement.Insert
 }
 
 func (q *InsertQuery) IsValid() bool {
@@ -35,28 +31,16 @@ func (q *InsertQuery) Error() error {
 	return q.e
 }
 
-func (q *InsertQuery) String() string {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b)
+func (q *InsertQuery) Scan(s types.Scanner, b []byte, qargs []interface{}, idx *int) int {
+	return q.stmt.Scan(s, b, qargs, idx)
 }
 
-func (q *InsertQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b), q.args
+func (q *InsertQuery) ArgCount() int {
+	return q.stmt.ArgCount()
+}
+
+func (q *InsertQuery) Size(s types.Scanner) int {
+	return q.stmt.Size(s)
 }
 
 // Given a table and a map of column name to value for that column to insert,
@@ -82,8 +66,7 @@ func Insert(t *ast.TableIdentifier, values map[string]interface{}) *InsertQuery 
 	}
 
 	return &InsertQuery{
-		stmt:    statement.NewInsert(t, cols, vals),
-		scanner: scanner.New(t.Schema().Dialect),
+		stmt: statement.NewInsert(t, cols, vals),
 	}
 }
 

--- a/insert.go
+++ b/insert.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
@@ -22,7 +23,7 @@ type InsertQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	stmt    *ast.InsertStatement
+	stmt    *statement.Insert
 	scanner types.Scanner
 }
 
@@ -80,11 +81,9 @@ func Insert(t *ast.TableIdentifier, values map[string]interface{}) *InsertQuery 
 		x++
 	}
 
-	scanner := scanner.New(t.Schema().Dialect)
-	stmt := ast.NewInsertStatement(t, cols, vals)
 	return &InsertQuery{
-		stmt:    stmt,
-		scanner: scanner,
+		stmt:    statement.NewInsert(t, cols, vals),
+		scanner: scanner.New(t.Schema().Dialect),
 	}
 }
 

--- a/insert_test.go
+++ b/insert_test.go
@@ -8,6 +8,7 @@ package sqlb
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -57,7 +58,8 @@ func TestInsertQuery(t *testing.T) {
 			assert.Fail(qe.Error())
 			continue
 		}
-		qs, qargs := test.q.StringArgs()
+		scan := scanner.DefaultScanner
+		qs, qargs := scan.StringArgs(test.q)
 		assert.Equal(len(test.qargs), len(qargs))
 		assert.Equal(test.qs, qs)
 	}

--- a/pkg/ast/derived.go
+++ b/pkg/ast/derived.go
@@ -27,34 +27,24 @@ import (
 // of the derived table as the selection alias (u instead of users).
 type DerivedTable struct {
 	Alias string
-	from  *SelectStatement
+	from  types.Selection
 }
 
 // DerivedColumns returns a collection of DerivedColumn projections that have
 // been constructed to refer to this derived table and not have any outer alias
 func (dt *DerivedTable) DerivedColumns() []types.Projection {
-	nprojs := len(dt.from.projs)
-	projs := make([]types.Projection, nprojs)
-	for x := 0; x < nprojs; x++ {
-		p := dt.from.projs[x]
+	projs := []types.Projection{}
+	for _, p := range dt.from.Projections() {
 		switch p.(type) {
 		case *ColumnIdentifier:
-			projs[x] = &DerivedColumn{dt: dt, c: p.(*ColumnIdentifier)}
+			projs = append(projs, &DerivedColumn{dt: dt, c: p.(*ColumnIdentifier)})
 		}
 	}
 	return projs
 }
 
 func (dt *DerivedTable) Projections() []types.Projection {
-	nprojs := len(dt.from.projs)
-	projs := make([]types.Projection, nprojs)
-	for x := 0; x < nprojs; x++ {
-		p := dt.from.projs[x]
-		switch p.(type) {
-		case *ColumnIdentifier:
-		}
-	}
-	return projs
+	return dt.from.Projections()
 }
 
 func (dt *DerivedTable) ArgCount() int {
@@ -82,7 +72,7 @@ func (dt *DerivedTable) Scan(scanner types.Scanner, b []byte, args []interface{}
 // the FROM clause.
 func NewDerivedTable(
 	alias string,
-	sel *SelectStatement,
+	sel types.Selection,
 ) *DerivedTable {
 	return &DerivedTable{
 		Alias: alias,

--- a/pkg/ast/derived_test.go
+++ b/pkg/ast/derived_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -35,7 +36,7 @@ func TestDerived(t *testing.T) {
 		derivedTest{
 			c: ast.NewDerivedTable(
 				"u",
-				ast.NewSelectStatement(
+				statement.NewSelect(
 					[]types.Projection{
 						colUserName,
 					},

--- a/pkg/ast/from_clause.go
+++ b/pkg/ast/from_clause.go
@@ -1,0 +1,105 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ast
+
+import (
+	"github.com/jaypipes/sqlb/pkg/grammar"
+	"github.com/jaypipes/sqlb/pkg/types"
+)
+
+type FromClause struct {
+	selections []types.Selection
+	joins      []*JoinClause
+}
+
+func (s *FromClause) Selections() []types.Selection {
+	return s.selections
+}
+
+func (s *FromClause) Joins() []*JoinClause {
+	return s.joins
+}
+
+func (s *FromClause) ReplaceSelections(sels []types.Selection) {
+	s.selections = sels
+}
+
+func (s *FromClause) ArgCount() int {
+	argc := 0
+	for _, sel := range s.selections {
+		argc += sel.ArgCount()
+	}
+	for _, join := range s.joins {
+		argc += join.ArgCount()
+	}
+	return argc
+}
+
+func (s *FromClause) Size(scanner types.Scanner) int {
+	size := 0
+	nsels := len(s.selections)
+	if nsels > 0 {
+		size += len(grammar.Symbols[grammar.SYM_FROM])
+		for _, sel := range s.selections {
+			size += sel.Size(scanner)
+		}
+		size += (len(grammar.Symbols[grammar.SYM_COMMA_WS]) * (nsels - 1)) // the commas...
+		for _, join := range s.joins {
+			size += join.Size(scanner)
+		}
+	}
+	return size
+}
+
+func (s *FromClause) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+	bw := 0
+	nsels := len(s.selections)
+	if nsels > 0 {
+		bw += copy(b[bw:], grammar.Symbols[grammar.SYM_FROM])
+		for x, sel := range s.selections {
+			bw += sel.Scan(scanner, b[bw:], args, curArg)
+			if x != (nsels - 1) {
+				bw += copy(b[bw:], grammar.Symbols[grammar.SYM_COMMA_WS])
+			}
+		}
+		for _, join := range s.joins {
+			bw += join.Scan(scanner, b[bw:], args, curArg)
+		}
+	}
+	return bw
+}
+
+func (s *FromClause) AddJoin(jc *JoinClause) *FromClause {
+	s.joins = append(s.joins, jc)
+	return s
+}
+
+func (s *FromClause) RemoveSelection(toRemove types.Selection) {
+	idx := -1
+	for x, sel := range s.selections {
+		if sel == toRemove {
+			idx = x
+			break
+		}
+	}
+	if idx == -1 {
+		return
+	}
+	s.selections = append(s.selections[:idx], s.selections[idx+1:]...)
+}
+
+// NewFromClause returns a new FromClause struct that scans into a
+// FROM clause.
+func NewFromClause(
+	selections []types.Selection,
+	joins []*JoinClause,
+) *FromClause {
+	return &FromClause{
+		selections: selections,
+		joins:      joins,
+	}
+}

--- a/pkg/ast/from_clause_test.go
+++ b/pkg/ast/from_clause_test.go
@@ -1,0 +1,107 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaypipes/sqlb"
+	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/scanner"
+	"github.com/jaypipes/sqlb/pkg/testutil"
+	"github.com/jaypipes/sqlb/pkg/types"
+)
+
+func TestFromClause(t *testing.T) {
+	assert := assert.New(t)
+
+	sc := testutil.Schema()
+	users := sqlb.T(sc, "users")
+	articles := sqlb.T(sc, "articles")
+	articleStates := sqlb.T(sc, "article_states")
+
+	colUserID := users.C("id")
+	colArticleAuthor := articles.C("author")
+	colArticleState := articles.C("state")
+	colArticleStateID := articleStates.C("id")
+
+	tests := []struct {
+		name  string
+		s     *ast.FromClause
+		qs    string
+		qargs []interface{}
+	}{
+		{
+			name: "Table",
+			s: ast.NewFromClause(
+				[]types.Selection{users},
+				[]*ast.JoinClause{},
+			),
+			qs: "FROM users",
+		},
+		{
+			name: "aliased Table",
+			s: ast.NewFromClause(
+				[]types.Selection{users.As("u")},
+				[]*ast.JoinClause{},
+			),
+			qs: "FROM users AS u",
+		},
+		{
+			name: "Single JOIN",
+			s: ast.NewFromClause(
+				[]types.Selection{articles},
+				[]*ast.JoinClause{
+					ast.Join(
+						articles,
+						users,
+						ast.Equal(colArticleAuthor, colUserID),
+					),
+				},
+			),
+			qs: "FROM articles JOIN users ON articles.author = users.id",
+		},
+		{
+			name: "Multiple JOINs",
+			s: ast.NewFromClause(
+				[]types.Selection{articles},
+				[]*ast.JoinClause{
+					ast.Join(
+						articles,
+						users,
+						ast.Equal(colArticleAuthor, colUserID),
+					),
+					ast.Join(
+						articles,
+						articleStates,
+						ast.Equal(colArticleState, colArticleStateID),
+					),
+				},
+			),
+			qs: "FROM articles JOIN users ON articles.author = users.id JOIN article_states ON articles.state = article_states.id",
+		},
+	}
+	for _, test := range tests {
+		expArgc := len(test.qargs)
+		argc := test.s.ArgCount()
+		assert.Equal(expArgc, argc)
+
+		expLen := len(test.qs)
+		size := test.s.Size(scanner.DefaultScanner)
+		size += scanner.InterpolationLength(types.DIALECT_MYSQL, argc)
+		assert.Equal(expLen, size)
+
+		b := make([]byte, size)
+		curArg := 0
+		written := test.s.Scan(scanner.DefaultScanner, b, test.qargs, &curArg)
+
+		assert.Equal(written, size)
+		assert.Equal(test.qs, string(b))
+	}
+}

--- a/pkg/grammar/statement/delete.go
+++ b/pkg/grammar/statement/delete.go
@@ -4,21 +4,21 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast
+package statement
 
 import (
+	"github.com/jaypipes/sqlb/pkg/ast"
 	"github.com/jaypipes/sqlb/pkg/grammar"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 // DELETE FROM <table> WHERE <predicates>
-
-type DeleteStatement struct {
-	table *TableIdentifier
-	where *WhereClause
+type Delete struct {
+	table *ast.TableIdentifier
+	where *ast.WhereClause
 }
 
-func (s *DeleteStatement) ArgCount() int {
+func (s *Delete) ArgCount() int {
 	argc := 0
 	if s.where != nil {
 		argc += s.where.ArgCount()
@@ -26,7 +26,7 @@ func (s *DeleteStatement) ArgCount() int {
 	return argc
 }
 
-func (s *DeleteStatement) Size(scanner types.Scanner) int {
+func (s *Delete) Size(scanner types.Scanner) int {
 	size := len(grammar.Symbols[grammar.SYM_DELETE]) + len(s.table.Name)
 	if s.where != nil {
 		size += s.where.Size(scanner)
@@ -34,7 +34,7 @@ func (s *DeleteStatement) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (s *DeleteStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (s *Delete) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_DELETE])
 	// We don't add any table alias when outputting the table identifier
@@ -45,19 +45,22 @@ func (s *DeleteStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	return bw
 }
 
-func (s *DeleteStatement) AddWhere(e *Expression) *DeleteStatement {
+func (s *Delete) AddWhere(e *ast.Expression) *Delete {
 	if s.where == nil {
-		s.where = NewWhereClause(e)
+		s.where = ast.NewWhereClause(e)
 		return s
 	}
 	s.where.AddExpression(e)
 	return s
 }
 
-// NewDeleteStatement returns a new DeleteStatement struct that scans into a
-// DELETE SQL statement
-func NewDeleteStatement(table *TableIdentifier, where *WhereClause) *DeleteStatement {
-	return &DeleteStatement{
+// NewDelete returns a new DeleteStatement struct that scans into a DELETE SQL
+// statement
+func NewDelete(
+	table *ast.TableIdentifier,
+	where *ast.WhereClause,
+) *Delete {
+	return &Delete{
 		table: table,
 		where: where,
 	}

--- a/pkg/grammar/statement/delete_test.go
+++ b/pkg/grammar/statement/delete_test.go
@@ -4,13 +4,14 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast_test
+package statement_test
 
 import (
 	"testing"
 
 	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -26,18 +27,18 @@ func TestDeleteStatement(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *ast.DeleteStatement
+		s     *statement.Delete
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "DELETE no WHERE",
-			s:    ast.NewDeleteStatement(users, nil),
+			s:    statement.NewDelete(users, nil),
 			qs:   "DELETE FROM users",
 		},
 		{
 			name: "DELETE simple WHERE",
-			s: ast.NewDeleteStatement(
+			s: statement.NewDelete(
 				users,
 				ast.NewWhereClause(
 					ast.Equal(colUserName, "foo"),

--- a/pkg/grammar/statement/insert.go
+++ b/pkg/grammar/statement/insert.go
@@ -4,9 +4,10 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast
+package statement
 
 import (
+	"github.com/jaypipes/sqlb/pkg/ast"
 	"github.com/jaypipes/sqlb/pkg/grammar"
 	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -14,17 +15,17 @@ import (
 
 // INSERT INTO <table> (<columns>) VALUES (<values>)
 
-type InsertStatement struct {
-	table   *TableIdentifier
-	columns []*ColumnIdentifier
+type Insert struct {
+	table   *ast.TableIdentifier
+	columns []*ast.ColumnIdentifier
 	values  []interface{}
 }
 
-func (s *InsertStatement) ArgCount() int {
+func (s *Insert) ArgCount() int {
 	return len(s.values)
 }
 
-func (s *InsertStatement) Size(scanner types.Scanner) int {
+func (s *Insert) Size(scanner types.Scanner) int {
 	size := len(grammar.Symbols[grammar.SYM_INSERT]) + len(s.table.Name) + 1 // space after table name
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -42,7 +43,7 @@ func (s *InsertStatement) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (s *InsertStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (s *Insert) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_INSERT])
 	// We don't add any table alias when outputting the table identifier
@@ -72,14 +73,14 @@ func (s *InsertStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	return bw
 }
 
-// NewInsertStatement returns a new InsertStatement struct that scans into an
+// NewInsert returns a new InsertStatement struct that scans into an
 // INSERT SQL statement
-func NewInsertStatement(
-	table *TableIdentifier,
-	columns []*ColumnIdentifier,
+func NewInsert(
+	table *ast.TableIdentifier,
+	columns []*ast.ColumnIdentifier,
 	values []interface{},
-) *InsertStatement {
-	return &InsertStatement{
+) *Insert {
+	return &Insert{
 		table:   table,
 		columns: columns,
 		values:  values,

--- a/pkg/grammar/statement/insert_test.go
+++ b/pkg/grammar/statement/insert_test.go
@@ -4,13 +4,14 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast_test
+package statement_test
 
 import (
 	"testing"
 
 	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -27,13 +28,13 @@ func TestInsertStatement(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *ast.InsertStatement
+		s     *statement.Insert
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "Simple INSERT",
-			s: ast.NewInsertStatement(
+			s: statement.NewInsert(
 				users,
 				[]*ast.ColumnIdentifier{colUserId, colUserName},
 				[]interface{}{nil, "foo"},
@@ -43,7 +44,7 @@ func TestInsertStatement(t *testing.T) {
 		},
 		{
 			name: "Ensure no aliasing in table names",
-			s: ast.NewInsertStatement(
+			s: statement.NewInsert(
 				users.As("u"),
 				[]*ast.ColumnIdentifier{colUserId, colUserName},
 				[]interface{}{nil, "foo"},
@@ -53,7 +54,7 @@ func TestInsertStatement(t *testing.T) {
 		},
 		{
 			name: "Ensure no aliasing in column names",
-			s: ast.NewInsertStatement(
+			s: statement.NewInsert(
 				users,
 				[]*ast.ColumnIdentifier{colUserId.As("user_id"), colUserName},
 				[]interface{}{nil, "foo"},

--- a/pkg/grammar/statement/select_test.go
+++ b/pkg/grammar/statement/select_test.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast_test
+package statement_test
 
 import (
 	"testing"
@@ -13,12 +13,13 @@ import (
 
 	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
-func TestSelectClause(t *testing.T) {
+func TestSelectStatement(t *testing.T) {
 	assert := assert.New(t)
 
 	sc := testutil.Schema()
@@ -35,13 +36,13 @@ func TestSelectClause(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *ast.SelectStatement
+		s     *statement.Select
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "A literal value",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{ast.NewValue(nil, 1)},
 				nil, nil, nil, nil, nil, nil, nil,
 			),
@@ -50,7 +51,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "A literal value aliased",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{ast.NewValue(nil, 1).As("foo")},
 				nil, nil, nil, nil, nil, nil, nil,
 			),
@@ -59,7 +60,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Two literal values",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{
 					ast.NewValue(nil, 1),
 					ast.NewValue(nil, 2),
@@ -71,7 +72,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and column",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil, nil, nil, nil, nil, nil,
@@ -80,7 +81,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "aliased Table and Column",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{
 					users.As("u").C("name"),
 				},
@@ -91,7 +92,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Table and multiple Column",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserId, colUserName},
 				[]types.Selection{users},
 				nil, nil, nil, nil, nil, nil,
@@ -100,7 +101,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple WHERE",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil,
@@ -114,7 +115,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple LIMIT",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil, nil, nil, nil, nil,
@@ -125,7 +126,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple ORDER BY",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil, nil, nil, nil,
@@ -136,7 +137,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Simple GROUP BY",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil, nil,
@@ -147,7 +148,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "GROUP BY, ORDER BY and LIMIT",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colUserName},
 				[]types.Selection{users},
 				nil, nil,
@@ -161,7 +162,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Single JOIN",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colArticleId, colUserName.As("author")},
 				[]types.Selection{articles},
 				[]*ast.JoinClause{
@@ -177,7 +178,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "Multiple JOINs",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{colArticleId, colUserName.As("author"), colArticleStateName.As("state")},
 				[]types.Selection{articles},
 				[]*ast.JoinClause{
@@ -198,7 +199,7 @@ func TestSelectClause(t *testing.T) {
 		},
 		{
 			name: "COUNT(*) on a table",
-			s: ast.NewSelectStatement(
+			s: statement.NewSelect(
 				[]types.Projection{ast.Count(users)},
 				[]types.Selection{users},
 				nil, nil, nil, nil, nil, nil,

--- a/pkg/grammar/statement/update.go
+++ b/pkg/grammar/statement/update.go
@@ -4,24 +4,24 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast
+package statement
 
 import (
+	"github.com/jaypipes/sqlb/pkg/ast"
 	"github.com/jaypipes/sqlb/pkg/grammar"
 	pkgscanner "github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
 
 // UPDATE <table> SET <column_value_list>[ WHERE <predicates>]
-
-type UpdateStatement struct {
-	table   *TableIdentifier
-	columns []*ColumnIdentifier
+type Update struct {
+	table   *ast.TableIdentifier
+	columns []*ast.ColumnIdentifier
 	values  []interface{}
-	where   *WhereClause
+	where   *ast.WhereClause
 }
 
-func (s *UpdateStatement) ArgCount() int {
+func (s *Update) ArgCount() int {
 	argc := len(s.values)
 	if s.where != nil {
 		argc += s.where.ArgCount()
@@ -29,7 +29,7 @@ func (s *UpdateStatement) ArgCount() int {
 	return argc
 }
 
-func (s *UpdateStatement) Size(scanner types.Scanner) int {
+func (s *Update) Size(scanner types.Scanner) int {
 	size := len(grammar.Symbols[grammar.SYM_UPDATE]) + len(s.table.Name) + len(grammar.Symbols[grammar.SYM_SET])
 	ncols := len(s.columns)
 	for _, c := range s.columns {
@@ -49,7 +49,7 @@ func (s *UpdateStatement) Size(scanner types.Scanner) int {
 	return size
 }
 
-func (s *UpdateStatement) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
+func (s *Update) Scan(scanner types.Scanner, b []byte, args []interface{}, curArg *int) int {
 	bw := 0
 	bw += copy(b[bw:], grammar.Symbols[grammar.SYM_UPDATE])
 	// We don't add any table alias when outputting the table identifier
@@ -77,24 +77,24 @@ func (s *UpdateStatement) Scan(scanner types.Scanner, b []byte, args []interface
 	return bw
 }
 
-func (s *UpdateStatement) AddWhere(e *Expression) *UpdateStatement {
+func (s *Update) AddWhere(e *ast.Expression) *Update {
 	if s.where == nil {
-		s.where = NewWhereClause(e)
+		s.where = ast.NewWhereClause(e)
 		return s
 	}
 	s.where.AddExpression(e)
 	return s
 }
 
-// NewUpdateStatement returns a new UpdateStatement struct that scans into an
-// UPDATE SQL statement
-func NewUpdateStatement(
-	table *TableIdentifier,
-	columns []*ColumnIdentifier,
+// NewUpdate returns a new UpdateStatement struct that scans into an UPDATE SQL
+// statement
+func NewUpdate(
+	table *ast.TableIdentifier,
+	columns []*ast.ColumnIdentifier,
 	values []interface{},
-	where *WhereClause,
-) *UpdateStatement {
-	return &UpdateStatement{
+	where *ast.WhereClause,
+) *Update {
+	return &Update{
 		table:   table,
 		columns: columns,
 		values:  values,

--- a/pkg/grammar/statement/update_test.go
+++ b/pkg/grammar/statement/update_test.go
@@ -4,13 +4,14 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ast_test
+package statement_test
 
 import (
 	"testing"
 
 	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -26,13 +27,13 @@ func TestUpdateStatement(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		s     *ast.UpdateStatement
+		s     *statement.Update
 		qs    string
 		qargs []interface{}
 	}{
 		{
 			name: "UPDATE no WHERE",
-			s: ast.NewUpdateStatement(
+			s: statement.NewUpdate(
 				users,
 				[]*ast.ColumnIdentifier{colUserName},
 				[]interface{}{"foo"},
@@ -43,7 +44,7 @@ func TestUpdateStatement(t *testing.T) {
 		},
 		{
 			name: "UPDATE simple WHERE",
-			s: ast.NewUpdateStatement(
+			s: statement.NewUpdate(
 				users,
 				[]*ast.ColumnIdentifier{colUserName},
 				[]interface{}{"foo"},

--- a/pkg/scanner/format_test.go
+++ b/pkg/scanner/format_test.go
@@ -3,13 +3,14 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
-package sqlb
+
+package scanner_test
 
 import (
 	"testing"
 
+	"github.com/jaypipes/sqlb"
 	"github.com/jaypipes/sqlb/pkg/ast"
-	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/jaypipes/sqlb/pkg/types"
@@ -20,43 +21,31 @@ func TestFormatOptions(t *testing.T) {
 	assert := assert.New(t)
 
 	sc := testutil.Schema()
-	users := T(sc, "users")
-	articles := T(sc, "articles")
+	users := sqlb.T(sc, "users")
+	articles := sqlb.T(sc, "articles")
 	colUserName := users.C("name")
 	colUserId := users.C("id")
 	colArticleId := articles.C("id")
 	colArticleAuthor := articles.C("author")
 
-	stmt := statement.NewSelect(
-		[]types.Projection{colArticleId, colUserName.As("author")},
-		[]types.Selection{articles},
-		[]*ast.JoinClause{
-			ast.Join(
-				articles,
-				users,
-				ast.Equal(colArticleAuthor, colUserId),
-			),
-		},
-		ast.NewWhereClause(
-			ast.Equal(colUserName, "foo"),
-		),
-		ast.NewGroupByClause(colUserName),
-		nil,
-		ast.NewOrderByClause(colUserName.Desc()),
-		ast.NewLimitClause(10, nil),
-	)
+	q := sqlb.Select(colArticleId, colUserName.As("author"))
+	q.Join(articles, ast.Equal(colUserId, colArticleAuthor))
+	q.Where(ast.Equal(colUserName, "foo"))
+	q.GroupBy(colUserName)
+	q.OrderBy(colUserName.Desc())
+	q.Limit(10)
 
 	tests := []struct {
 		name    string
 		scanner types.Scanner
-		s       *statement.Select
+		query   types.Element
 		qs      string
 		qargs   []interface{}
 	}{
 		{
 			name:  "default space clause separator",
-			s:     stmt,
-			qs:    "SELECT articles.id, users.name AS author FROM articles JOIN users ON articles.author = users.id WHERE users.name = ? GROUP BY users.name ORDER BY users.name DESC LIMIT ?",
+			query: q,
+			qs:    "SELECT articles.id, users.name AS author FROM users JOIN articles ON users.id = articles.author WHERE users.name = ? GROUP BY users.name ORDER BY users.name DESC LIMIT ?",
 			qargs: []interface{}{"foo", 10},
 		},
 		{
@@ -66,10 +55,10 @@ func TestFormatOptions(t *testing.T) {
 					SeparateClauseWith: "\n",
 				},
 			),
-			s: stmt,
+			query: q,
 			qs: `SELECT articles.id, users.name AS author
-FROM articles
-JOIN users ON articles.author = users.id
+FROM users
+JOIN articles ON users.id = articles.author
 WHERE users.name = ?
 GROUP BY users.name
 ORDER BY users.name DESC
@@ -84,11 +73,11 @@ LIMIT ?`,
 					PrefixWith:         "\n",
 				},
 			),
-			s: stmt,
+			query: q,
 			qs: `
 SELECT articles.id, users.name AS author
-FROM articles
-JOIN users ON articles.author = users.id
+FROM users
+JOIN articles ON users.id = articles.author
 WHERE users.name = ?
 GROUP BY users.name
 ORDER BY users.name DESC
@@ -101,12 +90,8 @@ LIMIT ?`,
 		if sc == nil {
 			sc = scanner.DefaultScanner
 		}
-		sel := &SelectQuery{
-			sel:     test.s,
-			scanner: sc,
-		}
-		qs, qargs := sel.StringArgs()
-		assert.Equal(qs, test.qs)
-		assert.Equal(qargs, test.qargs)
+		qs, qargs := sc.StringArgs(test.query)
+		assert.Equal(test.qs, qs)
+		assert.Equal(test.qargs, qargs)
 	}
 }

--- a/pkg/scanner/new.go
+++ b/pkg/scanner/new.go
@@ -45,6 +45,16 @@ func (s *sqlScanner) Size(elements ...types.Element) *types.ElementSizes {
 	}
 }
 
+// StringArgs returns the built query string and a slice of interface{}
+// representing the values of the query args used in the query string, if any.
+func (s *sqlScanner) StringArgs(el types.Element) (string, []interface{}) {
+	sizes := s.Size(el)
+	qargs := make([]interface{}, sizes.ArgCount)
+	b := make([]byte, sizes.BufferSize)
+	s.Scan(b, qargs, el)
+	return string(b), qargs
+}
+
 func (s *sqlScanner) Dialect() types.Dialect {
 	return s.dialect
 }

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -6,8 +6,10 @@
 
 package types
 
+// Scannable is a thing that knows how to describe itself to a Scanner for
+// construction in a SQL query string and query argument list.
 type Scannable interface {
-	// scan takes two slices and a pointer to an int. The first slice is a
+	// Scan takes two slices and a pointer to an int. The first slice is a
 	// slice of bytes that the implementation should copy its string
 	// representation to and the other slice is a slice of interface{} values
 	// that the element should add its arguments to. The pointer to an int is
@@ -16,17 +18,18 @@ type Scannable interface {
 	Scan(Scanner, []byte, []interface{}, *int) int
 }
 
+// Element adds a Size and ArgCount method to the Scannable interface
 type Element interface {
 	Scannable
-	// Returns the number of bytes that the scannable element would consume as
-	// a SQL string
+	// Size returns the number of bytes that the scannable element would
+	// consume as a SQL string
 	Size(Scanner) int
-	// Returns the number of interface{} arguments that the element will add to
-	// the slice of interface{} arguments passed to Scan()
+	// ArgCount returns the number of interface{} arguments that the element
+	// will add to the slice of interface{} arguments passed to Scan()
 	ArgCount() int
 }
 
-// A projection is something that produces a scalar value. A column, column
+// Projection is something that produces a scalar value. A column, column
 // definition, function, etc. When appearing in the SELECT clause's projection
 // list, the projection will output itself using the "AS alias" extended
 // notation. When outputting in GROUP BY, ORDER BY or ON clauses, the
@@ -39,7 +42,7 @@ type Projection interface {
 	DisableAliasScan() func()
 }
 
-// A selection is something that produces rows. A table, table definition,
+// Selection is something that produces rows. A table, table definition,
 // view, subselect, etc.
 type Selection interface {
 	Element

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -17,16 +17,13 @@ type Scannable interface {
 }
 
 type Element interface {
+	Scannable
 	// Returns the number of bytes that the scannable element would consume as
 	// a SQL string
 	Size(Scanner) int
 	// Returns the number of interface{} arguments that the element will add to
 	// the slice of interface{} arguments passed to Scan()
 	ArgCount() int
-	// scan takes two slices and a pointer to an int. The first slice is a slice of bytes that the
-	// implementation should copy its string representation to and the other slice is a slice of interface{} values that the element should add its
-	// arguments to. The pointer to an int is the index of the current argument to be processed. The method returns a single int, the number of bytes written to the buffer.
-	Scan(Scanner, []byte, []interface{}, *int) int
 }
 
 // A projection is something that produces a scalar value. A column, column
@@ -35,11 +32,8 @@ type Element interface {
 // notation. When outputting in GROUP BY, ORDER BY or ON clauses, the
 // projection will not include the alias extension
 type Projection interface {
+	Element
 	From() Selection
-	// projections must also implement element
-	Size(Scanner) int
-	ArgCount() int
-	Scan(Scanner, []byte, []interface{}, *int) int
 	// disables the outputting of the "AS alias" extended output. Returns a
 	// function that resets the outputting of the "AS alias" extended output
 	DisableAliasScan() func()
@@ -48,18 +42,6 @@ type Projection interface {
 // A selection is something that produces rows. A table, table definition,
 // view, subselect, etc.
 type Selection interface {
+	Element
 	Projections() []Projection
-	// selections must also implement element
-	Size(Scanner) int
-	ArgCount() int
-	Scan(Scanner, []byte, []interface{}, *int) int
-}
-
-// A Query is a placeholder for something that can be asked for the SQL string
-// representation of the underlying query clauses
-type Query interface {
-	IsValid() bool
-	Error() error
-	String() string
-	StringArgs() (string, []interface{})
 }

--- a/pkg/types/scanner.go
+++ b/pkg/types/scanner.go
@@ -25,4 +25,8 @@ type Scanner interface {
 	WithDialect(Dialect) Scanner
 	FormatOptions() *FormatOptions
 	WithFormatOptions(*FormatOptions) Scanner
+	// StringArgs returns the built query string and a slice of interface{}
+	// representing the values of the query args used in the query string, if
+	// any.
+	StringArgs(Element) (string, []interface{})
 }

--- a/query.go
+++ b/query.go
@@ -1,0 +1,38 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package sqlb
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jaypipes/sqlb/pkg/scanner"
+	"github.com/jaypipes/sqlb/pkg/types"
+)
+
+// Query accepts a `database/sql` `DB` handle and a `pkg/types.Element` and
+// calls the `databases/sql.DB.Query` method on the SQL string produced by the
+// `Element`.
+func Query(
+	db *sql.DB,
+	el types.Element,
+) (*sql.Rows, error) {
+	return QueryContext(context.TODO(), db, el)
+}
+
+// QueryContext accepts a `databases/sql` `DB` handle and a
+// `pkg/types.Element` and calls the `databases/sql.DB.Query` method on the
+// SQL string produced by the `Element`.
+func QueryContext(
+	ctx context.Context,
+	db *sql.DB,
+	el types.Element,
+) (*sql.Rows, error) {
+	s := scanner.New(types.DIALECT_UNKNOWN)
+	qs, qargs := s.StringArgs(el)
+	return db.QueryContext(ctx, qs, qargs...)
+}

--- a/select.go
+++ b/select.go
@@ -3,6 +3,7 @@
 //
 // See the COPYING file in the root project directory for full text.
 //
+
 package sqlb
 
 import (
@@ -10,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
@@ -23,7 +25,7 @@ type SelectQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	sel     *ast.SelectStatement
+	sel     *statement.Select
 	scanner types.Scanner
 }
 
@@ -93,7 +95,7 @@ func (q *SelectQuery) LimitWithOffset(limit int, offset int) *SelectQuery {
 // to the supplied name
 func (q *SelectQuery) As(alias string) *SelectQuery {
 	dt := ast.NewDerivedTable(alias, q.sel)
-	derivedSel := ast.NewSelectStatement(
+	derivedSel := statement.NewSelect(
 		dt.DerivedColumns(),
 		[]types.Selection{dt},
 		nil, nil, nil, nil, nil, nil,
@@ -259,7 +261,7 @@ func Select(items ...interface{}) *SelectQuery {
 	sq := &SelectQuery{
 		scanner: scanner,
 	}
-	sel := ast.NewSelectStatement(make([]types.Projection, 0), nil, nil, nil, nil, nil, nil, nil)
+	sel := statement.NewSelect(make([]types.Projection, 0), nil, nil, nil, nil, nil, nil, nil)
 
 	nDerived := 0
 	selectionMap := make(map[types.Selection]bool, 0)

--- a/update.go
+++ b/update.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/grammar/statement"
 	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/types"
 )
@@ -23,7 +24,7 @@ type UpdateQuery struct {
 	e       error
 	b       []byte
 	args    []interface{}
-	stmt    *ast.UpdateStatement
+	stmt    *statement.Update
 	scanner types.Scanner
 }
 
@@ -89,11 +90,9 @@ func Update(t *ast.TableIdentifier, values map[string]interface{}) *UpdateQuery 
 		x++
 	}
 
-	scanner := scanner.New(t.Schema().Dialect)
-	stmt := ast.NewUpdateStatement(t, cols, vals, nil)
 	return &UpdateQuery{
-		stmt:    stmt,
-		scanner: scanner,
+		scanner: scanner.New(t.Schema().Dialect),
+		stmt:    statement.NewUpdate(t, cols, vals, nil),
 	}
 }
 

--- a/update.go
+++ b/update.go
@@ -36,28 +36,16 @@ func (q *UpdateQuery) Error() error {
 	return q.e
 }
 
-func (q *UpdateQuery) String() string {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b)
+func (q *UpdateQuery) Scan(s types.Scanner, b []byte, qargs []interface{}, idx *int) int {
+	return q.stmt.Scan(s, b, qargs, idx)
 }
 
-func (q *UpdateQuery) StringArgs() (string, []interface{}) {
-	sizes := q.scanner.Size(q.stmt)
-	if len(q.args) != sizes.ArgCount {
-		q.args = make([]interface{}, sizes.ArgCount)
-	}
-	if len(q.b) != sizes.BufferSize {
-		q.b = make([]byte, sizes.BufferSize)
-	}
-	q.scanner.Scan(q.b, q.args, q.stmt)
-	return string(q.b), q.args
+func (q *UpdateQuery) ArgCount() int {
+	return q.stmt.ArgCount()
+}
+
+func (q *UpdateQuery) Size(s types.Scanner) int {
+	return q.stmt.Size(s)
 }
 
 func (q *UpdateQuery) Where(e *ast.Expression) *UpdateQuery {

--- a/update_test.go
+++ b/update_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jaypipes/sqlb/pkg/ast"
+	"github.com/jaypipes/sqlb/pkg/scanner"
 	"github.com/jaypipes/sqlb/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,7 +73,8 @@ func TestUpdateQuery(t *testing.T) {
 			assert.Fail(qe.Error())
 			continue
 		}
-		qs, qargs := test.q.StringArgs()
+		scan := scanner.DefaultScanner
+		qs, qargs := scan.StringArgs(test.q)
 		assert.Equal(len(test.qargs), len(qargs))
 		assert.Equal(test.qs, qs)
 	}


### PR DESCRIPTION
Teasing apart the awkward coupling between Scanner and the things that
can be queried. Introduces a new `sqlb.Query` and `sqlb.QueryContext`
functions that wrap the standard `database/sql.DB:Query` methods and
call the sqlb Scanner's StringArgs() method to produce a query string
and query arguments.
