### PR TITLE
add support for RegexSubstring()

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -100,26 +100,62 @@ var NoValues = api.NoValues
 var UnknownColumn = api.UnknownColumn
 var TableRequired = api.TableRequired
 
-/*
-// Max returns a Projection that contains the MAX() SQL function
-var Max = function.Max
+// Max returns a AggregateFunction that can be passed to a Select function to
+// create a MAX(<value expression>) SQL function.  The supplied argument should
+// be a ValueExpression or something that can be converted into a
+// ValueExpression.
+var Max = api.Max
 
-// Min returns a Projection that contains the MIN() SQL function
-var Min = function.Min
+// Min returns a AggregateFunction that can be passed to a Select function to
+// create a MIN(<value expression>) SQL function.  The supplied argument should
+// be a ValueExpression or something that can be converted into a
+// ValueExpression.
+var Min = api.Min
 
-// Sum returns a Projection that contains the SUM() SQL function
-var Sum = function.Sum
+// Sum returns a AggregateFunction that can be passed to a Select function to
+// create a SUM(<value expression>) SQL function.  The supplied argument should
+// be a ValueExpression or something that can be converted into a
+// ValueExpression.
+var Sum = api.Sum
 
-// Avg returns a Projection that contains the AVG() SQL function
-var Avg = function.Avg
+// Avg returns a AggregateFunction that can be passed to a Select function to
+// create a AVG(<value expression>) SQL function.  The supplied argument should
+// be a ValueExpression or something that can be converted into a
+// ValueExpression.
+var Avg = api.Avg
 
-// Count returns a Projection that contains the COUNT() SQL function
+// Count returns a AggregateFunction that can be passed to a Select function.
+// It accepts zero or one parameter. If no parameters are passed, the
+// AggregateFunction returned represents a COUNT(*) SQL function. If a
+// parameter is passed, it should be a ValueExpression or something that can be
+// converted into a ValueExpression.
 var Count = api.Count
 
-// CountDistint returns a Projection that contains the COUNT(x DISTINCT) SQL
-// function
-var CountDistinct = function.CountDistinct
+// Substring returns a SubstringFunction that produces a SUBSTRING() SQL
+// function that can be passed to sqlb constructs and functions like Select()
+//
+// The first argument is the subject of the SUBSTRING function and must be
+// coercible to a character value expression. The second argument is the FROM
+// portion of the SUBSTRING function, which is the index in the subject from
+// which to return a substring. The second argument must be coercible to a
+// numeric value expression.
+var Substring = api.Substring
 
+// RegexSubstring returns a RegexSubstringFunction that produces a SUBSTRING()
+// SQL function of the Regular Expression subtype that can be passed to sqlb
+// constructs and functions like Select()
+//
+// The first argument is the subject of the SUBSTRING function and must be
+// coercible to a character value expression. The second argument is the
+// SIMILAR portion of the SUBSTRING function, which is the regular expression
+// pattern to evaluate against the subject. The second argument must be
+// coercible to a character value expression. The third argument is the ESCAPE
+// portion of the SUBSTRING function, which is the characters that should be
+// used as an escape sequence for the regular expression. The third argument
+// must be coercible to a character value expression.
+var RegexSubstring = api.RegexSubstring
+
+/*
 // Cast returns a Projection that contains the CAST() SQL function
 var Cast = function.Cast
 

--- a/api/select.go
+++ b/api/select.go
@@ -413,7 +413,74 @@ func Select(
 				dc.As = &item.alias
 			}
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
-			//cols = append(cols, item)
+			if item.Referred != nil {
+				tname := ""
+				tp := &grammar.TablePrimary{}
+				t, ok := item.Referred.(*Table)
+				if ok {
+					tname = t.Name()
+					tp.TableName = &tname
+					if t.alias != "" {
+						tp.Correlation = &grammar.Correlation{
+							Name: t.Alias(),
+						}
+					}
+				} else {
+					// The column is from a derived table
+					dt := item.Referred.(*DerivedTable)
+					tname = dt.Name()
+					tp.DerivedTable = &grammar.DerivedTable{
+						Subquery: grammar.Subquery{
+							QueryExpression: grammar.QueryExpression{
+								Body: grammar.QueryExpressionBody{
+									NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
+										NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
+											Primary: &grammar.NonJoinQueryPrimary{
+												SimpleTable: &grammar.SimpleTable{
+													QuerySpecification: dt.Query(),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					// Derived tables are always named/aliased
+					tp.Correlation = &grammar.Correlation{
+						Name: dt.Name(),
+					}
+				}
+				tr := grammar.TableReference{Primary: tp}
+				trefByName[tname] = tr
+			}
+		case *RegexSubstringFunction:
+			if item == nil {
+				panic("specified a non-existent regex substring function")
+			}
+			dc := grammar.DerivedColumn{
+				ValueExpression: grammar.ValueExpression{
+					Common: &grammar.CommonValueExpression{
+						String: &grammar.StringValueExpression{
+							Character: &grammar.CharacterValueExpression{
+								Factor: &grammar.CharacterFactor{
+									Primary: grammar.CharacterPrimary{
+										Function: &grammar.StringValueFunction{
+											Character: &grammar.CharacterValueFunction{
+												RegexSubstring: item.RegexSubstringFunction,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			if item.alias != "" {
+				dc.As = &item.alias
+			}
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
 			if item.Referred != nil {
 				tname := ""
 				tp := &grammar.TablePrimary{}

--- a/grammar/string_value_function.go
+++ b/grammar/string_value_function.go
@@ -19,14 +19,6 @@ package grammar
 //      |     <normalize function>
 //      |     <specific type method>
 //
-// <character substring function>    ::=
-//          SUBSTRING <left paren> <character value expression> FROM <start position>
-//          [ FOR <string length> ] [ USING <char length units> ] <right paren>
-//
-// <regular expression substring function>    ::=
-//          SUBSTRING <left paren> <character value expression>
-//          SIMILAR <character value expression> ESCAPE <escape character> <right paren>
-//
 // <fold>    ::=   { UPPER | LOWER } <left paren> <character value expression> <right paren>
 //
 // <transcoding>    ::=   CONVERT <left paren> <character value expression> USING <transcoding name> <right paren>
@@ -92,6 +84,10 @@ type CharacterValueFunction struct {
 	SpecificType    *SpecificTypeFunction
 }
 
+// <character substring function>    ::=
+//          SUBSTRING <left paren> <character value expression> FROM <start position>
+//          [ FOR <string length> ] [ USING <char length units> ] <right paren>
+
 type SubstringFunction struct {
 	Subject CharacterValueExpression
 	From    NumericValueExpression
@@ -99,7 +95,15 @@ type SubstringFunction struct {
 	Using   CharacterLengthUnits
 }
 
-type RegexSubstringFunction struct{}
+// <regular expression substring function>    ::=
+//          SUBSTRING <left paren> <character value expression>
+//          SIMILAR <character value expression> ESCAPE <escape character> <right paren>
+
+type RegexSubstringFunction struct {
+	Subject CharacterValueExpression
+	Similar CharacterValueExpression
+	Escape  CharacterValueExpression
+}
 
 type FoldFunction struct{}
 

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -109,6 +109,8 @@ const (
 	SYM_UNIT_YEAR_MONTH
 	SYM_USING
 	SYM_FOR
+	SYM_SIMILAR
+	SYM_ESCAPE
 	SYM_PLACEHOLDER = 9999999999
 )
 
@@ -213,5 +215,7 @@ var (
 		SYM_UNIT_YEAR_MONTH:         []byte("YEAR_MONTH"),
 		SYM_USING:                   []byte("USING "),
 		SYM_FOR:                     []byte("FOR "),
+		SYM_SIMILAR:                 []byte("SIMILAR "),
+		SYM_ESCAPE:                  []byte("ESCAPE "),
 	}
 )

--- a/internal/builder/arg_count.go
+++ b/internal/builder/arg_count.go
@@ -171,6 +171,11 @@ func ArgCount(target interface{}, count *int) {
 			if ss.For != nil {
 				ArgCount(ss.For, count)
 			}
+		} else if el.RegexSubstring != nil {
+			ss := el.RegexSubstring
+			ArgCount(&ss.Subject, count)
+			ArgCount(&ss.Similar, count)
+			ArgCount(&ss.Escape, count)
 		}
 	case *grammar.QueryExpression:
 		ArgCount(&el.Body, count)

--- a/internal/builder/string_value_function.go
+++ b/internal/builder/string_value_function.go
@@ -27,6 +27,8 @@ func (b *Builder) doCharacterValueFunction(
 ) {
 	if el.Substring != nil {
 		b.doSubstringFunction(el.Substring, qargs, curarg)
+	} else if el.RegexSubstring != nil {
+		b.doRegexSubstringFunction(el.RegexSubstring, qargs, curarg)
 	}
 }
 
@@ -57,5 +59,21 @@ func (b *Builder) doSubstringFunction(
 		b.Write(grammar.Symbols[grammar.SYM_USING])
 		b.WriteString(grammar.CharacterLengthUnitsSymbol[el.Using])
 	}
+	b.Write(grammar.Symbols[grammar.SYM_RPAREN])
+}
+
+func (b *Builder) doRegexSubstringFunction(
+	el *grammar.RegexSubstringFunction,
+	qargs []interface{},
+	curarg *int,
+) {
+	b.Write(grammar.Symbols[grammar.SYM_SUBSTRING])
+	b.doCharacterValueExpression(&el.Subject, qargs, curarg)
+	b.WriteRune(' ')
+	b.Write(grammar.Symbols[grammar.SYM_SIMILAR])
+	b.doCharacterValueExpression(&el.Similar, qargs, curarg)
+	b.WriteRune(' ')
+	b.Write(grammar.Symbols[grammar.SYM_ESCAPE])
+	b.doCharacterValueExpression(&el.Escape, qargs, curarg)
 	b.Write(grammar.Symbols[grammar.SYM_RPAREN])
 }


### PR DESCRIPTION
The SUBSTRING() SQL function has a regular expression variant that looks like this:

```
SUBSTRING(<col> SIMILAR <pattern> ESCAPE <pattern>)
```

This patch adds support for this SQL function variant and aliases the Substring() and RegexSubstring() into the main `sqlb` package namespace.