### PR TITLE
DRY up SQL function handling

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -169,6 +169,22 @@ var Upper = api.Upper
 // to a character value expression.
 var Lower = api.Lower
 
+// Convert returns a TranscodingFunction that produces a CONVERT() SQL
+// function that can be passed to sqlb constructs and functions like Select()
+//
+// The first argument is the subject of the CONVERT function and must be
+// coercible to a character value expression. The second argument is the USING
+// portion of the CONVERT function.
+var Convert = api.Convert
+
+// Translate returns a TransliterationFunction that produces a TRANSLATE() SQL
+// function that can be passed to sqlb constructs and functions like Select()
+//
+// The first argument is the subject of the TRANSLATE function and must be
+// coercible to a character value expression. The second argument is the USING
+// portion of the TRANSLATE function.
+var Translate = api.Translate
+
 /*
 // Cast returns a Projection that contains the CAST() SQL function
 var Cast = function.Cast

--- a/api/derived_column.go
+++ b/api/derived_column.go
@@ -1,0 +1,176 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package api
+
+import "github.com/jaypipes/sqlb/grammar"
+
+// DerivedColumnFromAnyAndAlias returns a DerivedColumn from something that can
+// be coerced into a ValueExpression and an optional alias.
+//
+// If the first argument cannot be coerced into a ValueExpression, returns nil.
+func DerivedColumnFromAnyAndAlias(
+	subject interface{},
+	alias string,
+) *grammar.DerivedColumn {
+	var dc *grammar.DerivedColumn
+	switch v := subject.(type) {
+	case *grammar.DerivedColumn:
+		dc = v
+	case grammar.DerivedColumn:
+		dc = &v
+	case *grammar.AggregateFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Row: &grammar.RowValueExpression{
+					Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+						SetFunction: &grammar.SetFunctionSpecification{
+							Aggregate: v,
+						},
+					},
+				},
+			},
+		}
+	case *AggregateFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Row: &grammar.RowValueExpression{
+					Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+						SetFunction: &grammar.SetFunctionSpecification{
+							Aggregate: v.AggregateFunction,
+						},
+					},
+				},
+			},
+		}
+	case *SubstringFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Substring: v.SubstringFunction,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *grammar.SubstringFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Substring: v,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *RegexSubstringFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											RegexSubstring: v.RegexSubstringFunction,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *grammar.RegexSubstringFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											RegexSubstring: v,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *FoldFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Fold: v.FoldFunction,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *grammar.FoldFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Fold: v,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	if dc != nil {
+		if alias != "" {
+			dc.As = &alias
+		}
+	}
+	return dc
+}

--- a/api/derived_column.go
+++ b/api/derived_column.go
@@ -166,6 +166,46 @@ func DerivedColumnFromAnyAndAlias(
 				},
 			},
 		}
+	case *TranscodingFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Transcoding: v.TranscodingFunction,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *grammar.TranscodingFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Transcoding: v,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 	if dc != nil {
 		if alias != "" {

--- a/api/derived_column.go
+++ b/api/derived_column.go
@@ -206,6 +206,46 @@ func DerivedColumnFromAnyAndAlias(
 				},
 			},
 		}
+	case *TransliterationFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Transliteration: v.TransliterationFunction,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	case *grammar.TransliterationFunction:
+		dc = &grammar.DerivedColumn{
+			ValueExpression: grammar.ValueExpression{
+				Common: &grammar.CommonValueExpression{
+					String: &grammar.StringValueExpression{
+						Character: &grammar.CharacterValueExpression{
+							Factor: &grammar.CharacterFactor{
+								Primary: grammar.CharacterPrimary{
+									Function: &grammar.StringValueFunction{
+										Character: &grammar.CharacterValueFunction{
+											Transliteration: v,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 	if dc != nil {
 		if alias != "" {

--- a/api/select.go
+++ b/api/select.go
@@ -344,45 +344,8 @@ func Select(
 				dc.As = &item.alias
 			}
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
-			//cols = append(cols, item)
 			if item.Referred != nil {
-				tname := ""
-				tp := &grammar.TablePrimary{}
-				t, ok := item.Referred.(*Table)
-				if ok {
-					tname = t.Name()
-					tp.TableName = &tname
-					if t.alias != "" {
-						tp.Correlation = &grammar.Correlation{
-							Name: t.Alias(),
-						}
-					}
-				} else {
-					// The column is from a derived table
-					dt := item.Referred.(*DerivedTable)
-					tname = dt.Name()
-					tp.DerivedTable = &grammar.DerivedTable{
-						Subquery: grammar.Subquery{
-							QueryExpression: grammar.QueryExpression{
-								Body: grammar.QueryExpressionBody{
-									NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
-										NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
-											Primary: &grammar.NonJoinQueryPrimary{
-												SimpleTable: &grammar.SimpleTable{
-													QuerySpecification: dt.Query(),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-					// Derived tables are always named/aliased
-					tp.Correlation = &grammar.Correlation{
-						Name: dt.Name(),
-					}
-				}
+				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}
@@ -414,43 +377,7 @@ func Select(
 			}
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
 			if item.Referred != nil {
-				tname := ""
-				tp := &grammar.TablePrimary{}
-				t, ok := item.Referred.(*Table)
-				if ok {
-					tname = t.Name()
-					tp.TableName = &tname
-					if t.alias != "" {
-						tp.Correlation = &grammar.Correlation{
-							Name: t.Alias(),
-						}
-					}
-				} else {
-					// The column is from a derived table
-					dt := item.Referred.(*DerivedTable)
-					tname = dt.Name()
-					tp.DerivedTable = &grammar.DerivedTable{
-						Subquery: grammar.Subquery{
-							QueryExpression: grammar.QueryExpression{
-								Body: grammar.QueryExpressionBody{
-									NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
-										NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
-											Primary: &grammar.NonJoinQueryPrimary{
-												SimpleTable: &grammar.SimpleTable{
-													QuerySpecification: dt.Query(),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-					// Derived tables are always named/aliased
-					tp.Correlation = &grammar.Correlation{
-						Name: dt.Name(),
-					}
-				}
+				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}
@@ -482,43 +409,7 @@ func Select(
 			}
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
 			if item.Referred != nil {
-				tname := ""
-				tp := &grammar.TablePrimary{}
-				t, ok := item.Referred.(*Table)
-				if ok {
-					tname = t.Name()
-					tp.TableName = &tname
-					if t.alias != "" {
-						tp.Correlation = &grammar.Correlation{
-							Name: t.Alias(),
-						}
-					}
-				} else {
-					// The column is from a derived table
-					dt := item.Referred.(*DerivedTable)
-					tname = dt.Name()
-					tp.DerivedTable = &grammar.DerivedTable{
-						Subquery: grammar.Subquery{
-							QueryExpression: grammar.QueryExpression{
-								Body: grammar.QueryExpressionBody{
-									NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
-										NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
-											Primary: &grammar.NonJoinQueryPrimary{
-												SimpleTable: &grammar.SimpleTable{
-													QuerySpecification: dt.Query(),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-					// Derived tables are always named/aliased
-					tp.Correlation = &grammar.Correlation{
-						Name: dt.Name(),
-					}
-				}
+				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}
@@ -550,43 +441,7 @@ func Select(
 			}
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
 			if item.Referred != nil {
-				tname := ""
-				tp := &grammar.TablePrimary{}
-				t, ok := item.Referred.(*Table)
-				if ok {
-					tname = t.Name()
-					tp.TableName = &tname
-					if t.alias != "" {
-						tp.Correlation = &grammar.Correlation{
-							Name: t.Alias(),
-						}
-					}
-				} else {
-					// The column is from a derived table
-					dt := item.Referred.(*DerivedTable)
-					tname = dt.Name()
-					tp.DerivedTable = &grammar.DerivedTable{
-						Subquery: grammar.Subquery{
-							QueryExpression: grammar.QueryExpression{
-								Body: grammar.QueryExpressionBody{
-									NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
-										NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
-											Primary: &grammar.NonJoinQueryPrimary{
-												SimpleTable: &grammar.SimpleTable{
-													QuerySpecification: dt.Query(),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-					// Derived tables are always named/aliased
-					tp.Correlation = &grammar.Correlation{
-						Name: dt.Name(),
-					}
-				}
+				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}

--- a/api/select.go
+++ b/api/select.go
@@ -390,6 +390,19 @@ func Select(
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}
+		case *TransliterationFunction:
+			if item == nil {
+				panic("specified a non-existent tranliteration function")
+			}
+			dc := DerivedColumnFromAnyAndAlias(
+				item, item.alias,
+			)
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
+			if item.Referred != nil {
+				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
+				tr := grammar.TableReference{Primary: tp}
+				trefByName[tname] = tr
+			}
 		default:
 			// Everything else, make it a general literal value projection, so, for
 			// instance, a user can do SELECT 1, which is, technically

--- a/api/select.go
+++ b/api/select.go
@@ -329,21 +329,10 @@ func Select(
 			if item == nil {
 				panic("specified a non-existent aggregate function")
 			}
-			dc := grammar.DerivedColumn{
-				ValueExpression: grammar.ValueExpression{
-					Row: &grammar.RowValueExpression{
-						Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-							SetFunction: &grammar.SetFunctionSpecification{
-								Aggregate: item.AggregateFunction,
-							},
-						},
-					},
-				},
-			}
-			if item.alias != "" {
-				dc.As = &item.alias
-			}
-			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
+			dc := DerivedColumnFromAnyAndAlias(
+				item, item.alias,
+			)
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
 			if item.Referred != nil {
 				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
@@ -353,29 +342,10 @@ func Select(
 			if item == nil {
 				panic("specified a non-existent substring function")
 			}
-			dc := grammar.DerivedColumn{
-				ValueExpression: grammar.ValueExpression{
-					Common: &grammar.CommonValueExpression{
-						String: &grammar.StringValueExpression{
-							Character: &grammar.CharacterValueExpression{
-								Factor: &grammar.CharacterFactor{
-									Primary: grammar.CharacterPrimary{
-										Function: &grammar.StringValueFunction{
-											Character: &grammar.CharacterValueFunction{
-												Substring: item.SubstringFunction,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			if item.alias != "" {
-				dc.As = &item.alias
-			}
-			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
+			dc := DerivedColumnFromAnyAndAlias(
+				item, item.alias,
+			)
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
 			if item.Referred != nil {
 				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
@@ -385,29 +355,10 @@ func Select(
 			if item == nil {
 				panic("specified a non-existent regex substring function")
 			}
-			dc := grammar.DerivedColumn{
-				ValueExpression: grammar.ValueExpression{
-					Common: &grammar.CommonValueExpression{
-						String: &grammar.StringValueExpression{
-							Character: &grammar.CharacterValueExpression{
-								Factor: &grammar.CharacterFactor{
-									Primary: grammar.CharacterPrimary{
-										Function: &grammar.StringValueFunction{
-											Character: &grammar.CharacterValueFunction{
-												RegexSubstring: item.RegexSubstringFunction,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			if item.alias != "" {
-				dc.As = &item.alias
-			}
-			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
+			dc := DerivedColumnFromAnyAndAlias(
+				item, item.alias,
+			)
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
 			if item.Referred != nil {
 				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}
@@ -417,29 +368,10 @@ func Select(
 			if item == nil {
 				panic("specified a non-existent fold function")
 			}
-			dc := grammar.DerivedColumn{
-				ValueExpression: grammar.ValueExpression{
-					Common: &grammar.CommonValueExpression{
-						String: &grammar.StringValueExpression{
-							Character: &grammar.CharacterValueExpression{
-								Factor: &grammar.CharacterFactor{
-									Primary: grammar.CharacterPrimary{
-										Function: &grammar.StringValueFunction{
-											Character: &grammar.CharacterValueFunction{
-												Fold: item.FoldFunction,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			if item.alias != "" {
-				dc.As = &item.alias
-			}
-			sels = append(sels, grammar.SelectSublist{DerivedColumn: &dc})
+			dc := DerivedColumnFromAnyAndAlias(
+				item, item.alias,
+			)
+			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
 			if item.Referred != nil {
 				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
 				tr := grammar.TableReference{Primary: tp}

--- a/api/string_value_function.go
+++ b/api/string_value_function.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jaypipes/sqlb/grammar"
 )
@@ -237,6 +238,59 @@ type FoldFunction struct {
 
 // As aliases the SQL function as the supplied column name
 func (f *FoldFunction) As(alias string) *FoldFunction {
+	f.alias = alias
+	return f
+}
+
+// Convert returns a TranscodingFunction that produces a CONVERT() SQL
+// function that can be passed to sqlb constructs and functions like Select()
+//
+// The first argument is the subject of the CONVERT function and must be
+// coercible to a character value expression. The second argument is the USING
+// portion of the CONVERT function.
+func Convert(
+	subjectAny interface{},
+	using string,
+) *TranscodingFunction {
+	var ref interface{}
+	switch valAny := subjectAny.(type) {
+	case *Column:
+		ref = valAny.t
+	}
+	subject := CharacterValueExpressionFromAny(subjectAny)
+	if subject == nil {
+		msg := fmt.Sprintf(
+			"expected coerceable CharacterValueExpression but got %+v(%T)",
+			subjectAny, subjectAny,
+		)
+		panic(msg)
+	}
+	return &TranscodingFunction{
+		TranscodingFunction: &grammar.TranscodingFunction{
+			Subject: *subject,
+			Using: grammar.SchemaQualifiedName{
+				Identifiers: grammar.IdentifierChain{
+					Identifiers: strings.Split(using, "."),
+				},
+			},
+		},
+		Referred: ref,
+	}
+}
+
+// TranscodingFunction wraps the CONVERT() SQL function grammar element
+type TranscodingFunction struct {
+	*grammar.TranscodingFunction
+	// referred is a the Table or DerivedTable that is referred from
+	// the aggregate function
+	Referred interface{}
+	// alias is the function as an aliased projection (e.g. CONVERT(col USING
+	// charset) AS counter)
+	alias string
+}
+
+// As aliases the SQL function as the supplied column name
+func (f *TranscodingFunction) As(alias string) *TranscodingFunction {
 	f.alias = alias
 	return f
 }

--- a/api/string_value_function_test.go
+++ b/api/string_value_function_test.go
@@ -443,3 +443,132 @@ func TestSelectFoldFunction(t *testing.T) {
 		})
 	}
 }
+
+func TestStringValueFunctionTranscoding(t *testing.T) {
+	m := testutil.M()
+	users := m.T("users")
+	colUserId := users.C("id")
+
+	tests := []struct {
+		name            string
+		subject         interface{}
+		transcodingName string
+		exp             *api.TranscodingFunction
+	}{
+		{
+			name:            "CONVERT column",
+			subject:         colUserId,
+			transcodingName: "utf8",
+			exp: &api.TranscodingFunction{
+				TranscodingFunction: &grammar.TranscodingFunction{
+					Subject: grammar.CharacterValueExpression{
+						Factor: &grammar.CharacterFactor{
+							Primary: grammar.CharacterPrimary{
+								Primary: &grammar.ValueExpressionPrimary{
+									Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+										ColumnReference: &grammar.ColumnReference{
+											BasicIdentifierChain: &grammar.IdentifierChain{
+												Identifiers: []string{
+													"users",
+													"id",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Using: grammar.SchemaQualifiedName{
+						Identifiers: grammar.IdentifierChain{
+							Identifiers: []string{"utf8"},
+						},
+					},
+				},
+				Referred: users,
+			},
+		},
+		{
+			name:            "CONVERT string literal",
+			subject:         "foo",
+			transcodingName: "utf8",
+			exp: &api.TranscodingFunction{
+				TranscodingFunction: &grammar.TranscodingFunction{
+					Subject: grammar.CharacterValueExpression{
+						Factor: &grammar.CharacterFactor{
+							Primary: grammar.CharacterPrimary{
+								Primary: &grammar.ValueExpressionPrimary{
+									Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+										UnsignedValue: &grammar.UnsignedValueSpecification{
+											UnsignedLiteral: &grammar.UnsignedLiteral{
+												GeneralLiteral: &grammar.GeneralLiteral{
+													Value: "foo",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Using: grammar.SchemaQualifiedName{
+						Identifiers: grammar.IdentifierChain{
+							Identifiers: []string{"utf8"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := api.Convert(tt.subject, tt.transcodingName)
+			assert.Equal(tt.exp, got)
+		})
+	}
+
+	// First argument must be coercible into a CharacterValueExpression
+	assert.Panics(t, func() {
+		_ = api.Convert(struct{}{}, "utf8")
+	})
+	assert.Panics(t, func() {
+		// A Table is not coercible into a CharacterValueExpression
+		_ = api.Convert(users, "utf8")
+	})
+}
+
+func TestSelectTranscodingFunction(t *testing.T) {
+	m := testutil.M()
+	users := m.T("users")
+	colUserId := users.C("id")
+
+	tests := []struct {
+		name  string
+		q     *api.Selection
+		qs    string
+		qargs []interface{}
+	}{
+		{
+			name: "convert column",
+			q:    api.Select(api.Convert(colUserId, "utf8")),
+			qs:   "SELECT CONVERT(users.id USING utf8) FROM users",
+		},
+		{
+			name: "convert column with alias",
+			q:    api.Select(api.Convert(colUserId, "utf8").As("converted")),
+			qs:   "SELECT CONVERT(users.id USING utf8) AS converted FROM users",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			b := builder.New()
+
+			qs, qargs := b.StringArgs(tt.q.Query())
+			assert.Equal(len(tt.qargs), len(qargs))
+			assert.Equal(tt.qs, qs)
+		})
+	}
+}

--- a/api/table_primary.go
+++ b/api/table_primary.go
@@ -1,0 +1,58 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package api
+
+import (
+	"github.com/jaypipes/sqlb/grammar"
+)
+
+// NameAndTablePrimaryFromReferred evaluates the supplied interface argument
+// representing a referred table or derived table and returns a *TablePrimary
+// and the name of the referrent if the supplied argument can be converted into
+// a TablePrimary, or nil if the conversion cannot be done.
+func NameAndTablePrimaryFromReferred(
+	subject interface{},
+) (string, *grammar.TablePrimary) {
+	tname := ""
+	tp := &grammar.TablePrimary{}
+	t, ok := subject.(*Table)
+	if ok {
+		tname = t.Name()
+		tp.TableName = &tname
+		if t.alias != "" {
+			tp.Correlation = &grammar.Correlation{
+				Name: t.Alias(),
+			}
+		}
+	} else {
+		// The column is from a derived table
+		dt := subject.(*DerivedTable)
+		tname = dt.Name()
+		tp.DerivedTable = &grammar.DerivedTable{
+			Subquery: grammar.Subquery{
+				QueryExpression: grammar.QueryExpression{
+					Body: grammar.QueryExpressionBody{
+						NonJoinQueryExpression: &grammar.NonJoinQueryExpression{
+							NonJoinQueryTerm: &grammar.NonJoinQueryTerm{
+								Primary: &grammar.NonJoinQueryPrimary{
+									SimpleTable: &grammar.SimpleTable{
+										QuerySpecification: dt.Query(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		// Derived tables are always named/aliased
+		tp.Correlation = &grammar.Correlation{
+			Name: dt.Name(),
+		}
+	}
+	return tname, tp
+}

--- a/grammar/identifier.go
+++ b/grammar/identifier.go
@@ -122,3 +122,8 @@ type IdentifierChain struct {
 // <scope option>    ::=   GLOBAL | LOCAL
 //
 // <window name>    ::=   <identifier>
+
+type SchemaQualifiedName struct {
+	SchemaName  *string
+	Identifiers IdentifierChain
+}

--- a/grammar/string_value_function.go
+++ b/grammar/string_value_function.go
@@ -19,8 +19,6 @@ package grammar
 //      |     <normalize function>
 //      |     <specific type method>
 //
-// <transcoding>    ::=   CONVERT <left paren> <character value expression> USING <transcoding name> <right paren>
-//
 // <character transliteration>    ::=   TRANSLATE <left paren> <character value expression> USING <transliteration name> <right paren>
 //
 // <trim function>    ::=   TRIM <left paren> <trim operands> <right paren>
@@ -122,7 +120,12 @@ type FoldFunction struct {
 	Subject CharacterValueExpression
 }
 
-type TranscodingFunction struct{}
+// <transcoding>    ::=   CONVERT <left paren> <character value expression> USING <transcoding name> <right paren>
+
+type TranscodingFunction struct {
+	Subject CharacterValueExpression
+	Using   SchemaQualifiedName
+}
 
 type TransliterationFunction struct{}
 

--- a/grammar/string_value_function.go
+++ b/grammar/string_value_function.go
@@ -19,8 +19,6 @@ package grammar
 //      |     <normalize function>
 //      |     <specific type method>
 //
-// <character transliteration>    ::=   TRANSLATE <left paren> <character value expression> USING <transliteration name> <right paren>
-//
 // <trim function>    ::=   TRIM <left paren> <trim operands> <right paren>
 //
 // <trim operands>    ::=   [ [ <trim specification> ] [ <trim character> ] FROM ] <trim source>
@@ -127,7 +125,12 @@ type TranscodingFunction struct {
 	Using   SchemaQualifiedName
 }
 
-type TransliterationFunction struct{}
+// <character transliteration>    ::=   TRANSLATE <left paren> <character value expression> USING <transliteration name> <right paren>
+
+type TransliterationFunction struct {
+	Subject CharacterValueExpression
+	Using   SchemaQualifiedName
+}
 
 type TrimFunction struct{}
 

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -60,6 +60,7 @@ const (
 	SYM_COUNT_STAR
 	SYM_DISTINCT
 	SYM_CONVERT
+	SYM_TRANSLATE
 	SYM_CAST
 	SYM_BTRIM
 	SYM_SUBSTRING
@@ -168,6 +169,7 @@ var (
 		SYM_DISTINCT:                []byte("DISTINCT "),
 		SYM_CAST:                    []byte("CAST("),
 		SYM_CONVERT:                 []byte("CONVERT("),
+		SYM_TRANSLATE:               []byte("TRANSLATE("),
 		SYM_BTRIM:                   []byte("BTRIM("),
 		SYM_SUBSTRING:               []byte("SUBSTRING("),
 		SYM_TRIM:                    []byte("TRIM("),

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -59,6 +59,7 @@ const (
 	SYM_AVG
 	SYM_COUNT_STAR
 	SYM_DISTINCT
+	SYM_CONVERT
 	SYM_CAST
 	SYM_BTRIM
 	SYM_SUBSTRING
@@ -166,6 +167,7 @@ var (
 		SYM_COUNT_STAR:              []byte("COUNT(*)"),
 		SYM_DISTINCT:                []byte("DISTINCT "),
 		SYM_CAST:                    []byte("CAST("),
+		SYM_CONVERT:                 []byte("CONVERT("),
 		SYM_BTRIM:                   []byte("BTRIM("),
 		SYM_SUBSTRING:               []byte("SUBSTRING("),
 		SYM_TRIM:                    []byte("TRIM("),

--- a/internal/builder/arg_count.go
+++ b/internal/builder/arg_count.go
@@ -180,6 +180,8 @@ func ArgCount(target interface{}, count *int) {
 			ArgCount(&el.Fold.Subject, count)
 		} else if el.Transcoding != nil {
 			ArgCount(&el.Transcoding.Subject, count)
+		} else if el.Transliteration != nil {
+			ArgCount(&el.Transliteration.Subject, count)
 		}
 	case *grammar.QueryExpression:
 		ArgCount(&el.Body, count)

--- a/internal/builder/arg_count.go
+++ b/internal/builder/arg_count.go
@@ -178,6 +178,8 @@ func ArgCount(target interface{}, count *int) {
 			ArgCount(&ss.Escape, count)
 		} else if el.Fold != nil {
 			ArgCount(&el.Fold.Subject, count)
+		} else if el.Transcoding != nil {
+			ArgCount(&el.Transcoding.Subject, count)
 		}
 	case *grammar.QueryExpression:
 		ArgCount(&el.Body, count)

--- a/internal/builder/identifier.go
+++ b/internal/builder/identifier.go
@@ -19,3 +19,15 @@ func (b *Builder) doIdentifierChain(
 ) {
 	b.WriteString(strings.Join(el.Identifiers, "."))
 }
+
+func (b *Builder) doSchemaQualifiedName(
+	el *grammar.SchemaQualifiedName,
+	qargs []interface{},
+	curarg *int,
+) {
+	if el.SchemaName != nil {
+		b.WriteString(*el.SchemaName)
+		b.WriteRune('.')
+	}
+	b.doIdentifierChain(&el.Identifiers, qargs, curarg)
+}

--- a/internal/builder/string_value_function.go
+++ b/internal/builder/string_value_function.go
@@ -31,6 +31,8 @@ func (b *Builder) doCharacterValueFunction(
 		b.doRegexSubstringFunction(el.RegexSubstring, qargs, curarg)
 	} else if el.Fold != nil {
 		b.doFoldFunction(el.Fold, qargs, curarg)
+	} else if el.Transcoding != nil {
+		b.doTranscodingFunction(el.Transcoding, qargs, curarg)
 	}
 }
 
@@ -88,5 +90,18 @@ func (b *Builder) doFoldFunction(
 	b.WriteString(grammar.FoldCaseSymbols[el.Case])
 	b.Write(grammar.Symbols[grammar.SYM_LPAREN])
 	b.doCharacterValueExpression(&el.Subject, qargs, curarg)
+	b.Write(grammar.Symbols[grammar.SYM_RPAREN])
+}
+
+func (b *Builder) doTranscodingFunction(
+	el *grammar.TranscodingFunction,
+	qargs []interface{},
+	curarg *int,
+) {
+	b.Write(grammar.Symbols[grammar.SYM_CONVERT])
+	b.doCharacterValueExpression(&el.Subject, qargs, curarg)
+	b.WriteRune(' ')
+	b.Write(grammar.Symbols[grammar.SYM_USING])
+	b.doSchemaQualifiedName(&el.Using, qargs, curarg)
 	b.Write(grammar.Symbols[grammar.SYM_RPAREN])
 }

--- a/internal/builder/string_value_function.go
+++ b/internal/builder/string_value_function.go
@@ -33,6 +33,8 @@ func (b *Builder) doCharacterValueFunction(
 		b.doFoldFunction(el.Fold, qargs, curarg)
 	} else if el.Transcoding != nil {
 		b.doTranscodingFunction(el.Transcoding, qargs, curarg)
+	} else if el.Transliteration != nil {
+		b.doTransliterationFunction(el.Transliteration, qargs, curarg)
 	}
 }
 
@@ -99,6 +101,19 @@ func (b *Builder) doTranscodingFunction(
 	curarg *int,
 ) {
 	b.Write(grammar.Symbols[grammar.SYM_CONVERT])
+	b.doCharacterValueExpression(&el.Subject, qargs, curarg)
+	b.WriteRune(' ')
+	b.Write(grammar.Symbols[grammar.SYM_USING])
+	b.doSchemaQualifiedName(&el.Using, qargs, curarg)
+	b.Write(grammar.Symbols[grammar.SYM_RPAREN])
+}
+
+func (b *Builder) doTransliterationFunction(
+	el *grammar.TransliterationFunction,
+	qargs []interface{},
+	curarg *int,
+) {
+	b.Write(grammar.Symbols[grammar.SYM_TRANSLATE])
 	b.doCharacterValueExpression(&el.Subject, qargs, curarg)
 	b.WriteRune(' ')
 	b.Write(grammar.Symbols[grammar.SYM_USING])


### PR DESCRIPTION
Cleans up the SQL function handling in `api/` and adds support for the CONVERT()
and TRANSLATE() SQL functions.