### PR TITLE
add api.Projectable interface

### DIFF
--- a/api/aggregate_function_test.go
+++ b/api/aggregate_function_test.go
@@ -22,34 +22,31 @@ func TestAggregateFunctionCount(t *testing.T) {
 	colUserId := users.C("id")
 
 	tests := []struct {
-		name   string
-		target []interface{}
-		exp    *api.AggregateFunction
+		name        string
+		target      []interface{}
+		exp         *grammar.AggregateFunction
+		expRefersTo []interface{}
 	}{
 		{
 			name: "count star",
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					CountStar: &struct{}{},
-				},
+			exp: &grammar.AggregateFunction{
+				CountStar: &struct{}{},
 			},
 		},
 		{
 			name:   "column",
 			target: []interface{}{colUserId},
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation: grammar.ComputationalOperationCount,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation: grammar.ComputationalOperationCount,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -57,15 +54,16 @@ func TestAggregateFunctionCount(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := api.Count(tt.target...)
-			assert.Equal(tt.exp, got)
+			assert.Equal(tt.exp, got.AggregateFunction)
+			assert.Equal(tt.expRefersTo, got.RefersTo())
 		})
 	}
 
@@ -90,28 +88,27 @@ func TestAggregateFunctionAvgMinMaxSum(t *testing.T) {
 	colUserId := users.C("id")
 
 	tests := []struct {
-		name   string
-		target interface{}
-		f      func(interface{}) *api.AggregateFunction
-		exp    *api.AggregateFunction
+		name        string
+		target      interface{}
+		f           func(interface{}) *api.AggregateFunction
+		exp         *grammar.AggregateFunction
+		expRefersTo []interface{}
 	}{
 		{
 			name:   "avg column",
 			target: colUserId,
 			f:      api.Avg,
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation: grammar.ComputationalOperationAvg,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation: grammar.ComputationalOperationAvg,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -119,26 +116,24 @@ func TestAggregateFunctionAvgMinMaxSum(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 		{
 			name:   "min column",
 			target: colUserId,
 			f:      api.Min,
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation: grammar.ComputationalOperationMin,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation: grammar.ComputationalOperationMin,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -146,26 +141,24 @@ func TestAggregateFunctionAvgMinMaxSum(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 		{
 			name:   "max column",
 			target: colUserId,
 			f:      api.Max,
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation: grammar.ComputationalOperationMax,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation: grammar.ComputationalOperationMax,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -173,26 +166,24 @@ func TestAggregateFunctionAvgMinMaxSum(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 		{
 			name:   "sum column",
 			target: colUserId,
 			f:      api.Sum,
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation: grammar.ComputationalOperationSum,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation: grammar.ComputationalOperationSum,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -200,15 +191,16 @@ func TestAggregateFunctionAvgMinMaxSum(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := tt.f(tt.target)
-			assert.Equal(tt.exp, got)
+			assert.Equal(tt.exp, got.AggregateFunction)
+			assert.Equal(tt.expRefersTo, got.RefersTo())
 		})
 	}
 
@@ -233,29 +225,28 @@ func TestAggregateFunctionDistinct(t *testing.T) {
 	colUserId := users.C("id")
 
 	tests := []struct {
-		name   string
-		target interface{}
-		f      func(interface{}) *api.AggregateFunction
-		exp    *api.AggregateFunction
+		name        string
+		target      interface{}
+		f           func(interface{}) *api.AggregateFunction
+		exp         *grammar.AggregateFunction
+		expRefersTo []interface{}
 	}{
 		{
 			name:   "avg distinct column",
 			target: colUserId,
 			f:      api.Avg,
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					GeneralSetFunction: &grammar.GeneralSetFunction{
-						Operation:  grammar.ComputationalOperationAvg,
-						Quantifier: grammar.SetQuantifierDistinct,
-						ValueExpression: grammar.ValueExpression{
-							Row: &grammar.RowValueExpression{
-								Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-									ColumnReference: &grammar.ColumnReference{
-										BasicIdentifierChain: &grammar.IdentifierChain{
-											Identifiers: []string{
-												"users",
-												"id",
-											},
+			exp: &grammar.AggregateFunction{
+				GeneralSetFunction: &grammar.GeneralSetFunction{
+					Operation:  grammar.ComputationalOperationAvg,
+					Quantifier: grammar.SetQuantifierDistinct,
+					ValueExpression: grammar.ValueExpression{
+						Row: &grammar.RowValueExpression{
+							Primary: &grammar.NonParenthesizedValueExpressionPrimary{
+								ColumnReference: &grammar.ColumnReference{
+									BasicIdentifierChain: &grammar.IdentifierChain{
+										Identifiers: []string{
+											"users",
+											"id",
 										},
 									},
 								},
@@ -263,16 +254,14 @@ func TestAggregateFunctionDistinct(t *testing.T) {
 						},
 					},
 				},
-				Referred: users,
 			},
+			expRefersTo: []interface{}{users},
 		},
 		{
 			name: "count star is not affected with distinct",
 			f:    func(_ interface{}) *api.AggregateFunction { return api.Count() },
-			exp: &api.AggregateFunction{
-				AggregateFunction: &grammar.AggregateFunction{
-					CountStar: &struct{}{},
-				},
+			exp: &grammar.AggregateFunction{
+				CountStar: &struct{}{},
 			},
 		},
 	}
@@ -280,7 +269,8 @@ func TestAggregateFunctionDistinct(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			got := tt.f(tt.target).Distinct()
-			assert.Equal(tt.exp, got)
+			assert.Equal(tt.exp, got.AggregateFunction)
+			assert.Equal(tt.expRefersTo, got.RefersTo())
 		})
 	}
 

--- a/api/derived_column.go
+++ b/api/derived_column.go
@@ -22,6 +22,8 @@ func DerivedColumnFromAnyAndAlias(
 		dc = v
 	case grammar.DerivedColumn:
 		dc = &v
+	case Projectable:
+		dc = v.DerivedColumn()
 	case *grammar.AggregateFunction:
 		dc = &grammar.DerivedColumn{
 			ValueExpression: grammar.ValueExpression{
@@ -29,18 +31,6 @@ func DerivedColumnFromAnyAndAlias(
 					Primary: &grammar.NonParenthesizedValueExpressionPrimary{
 						SetFunction: &grammar.SetFunctionSpecification{
 							Aggregate: v,
-						},
-					},
-				},
-			},
-		}
-	case *AggregateFunction:
-		dc = &grammar.DerivedColumn{
-			ValueExpression: grammar.ValueExpression{
-				Row: &grammar.RowValueExpression{
-					Primary: &grammar.NonParenthesizedValueExpressionPrimary{
-						SetFunction: &grammar.SetFunctionSpecification{
-							Aggregate: v.AggregateFunction,
 						},
 					},
 				},

--- a/api/projectable.go
+++ b/api/projectable.go
@@ -1,0 +1,22 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package api
+
+import (
+	"github.com/jaypipes/sqlb/grammar"
+)
+
+// Projectable things can be included in a SELECT statement and allow
+// inspection of the tables or derived tables (subqueries) that they reference.
+type Projectable interface {
+	// RefersTo returns a slice of tables or derived tables that are referenced
+	// by the Projectable
+	RefersTo() []interface{}
+	// DerivedColumn returns the `*grammar.DerivedColumn` element representing
+	// the Projectable
+	DerivedColumn() *grammar.DerivedColumn
+}

--- a/api/select.go
+++ b/api/select.go
@@ -325,18 +325,19 @@ func Select(
 				tr := grammar.TableReference{Primary: tp}
 				trefByName[tname] = tr
 			}
-		case *AggregateFunction:
+		case Projectable:
 			if item == nil {
-				panic("specified a non-existent aggregate function")
+				panic("specified a non-existent projectable")
 			}
-			dc := DerivedColumnFromAnyAndAlias(
-				item, item.alias,
-			)
+			dc := item.DerivedColumn()
 			sels = append(sels, grammar.SelectSublist{DerivedColumn: dc})
-			if item.Referred != nil {
-				tname, tp := NameAndTablePrimaryFromReferred(item.Referred)
-				tr := grammar.TableReference{Primary: tp}
-				trefByName[tname] = tr
+			refs := item.RefersTo()
+			if len(refs) > 0 {
+				for _, ref := range refs {
+					tname, tp := NameAndTablePrimaryFromReferred(ref)
+					tr := grammar.TableReference{Primary: tp}
+					trefByName[tname] = tr
+				}
 			}
 		case *SubstringFunction:
 			if item == nil {

--- a/api/table.go
+++ b/api/table.go
@@ -229,7 +229,7 @@ func (t *Table) Count(args ...interface{}) *AggregateFunction {
 			AggregateFunction: &grammar.AggregateFunction{
 				CountStar: &struct{}{},
 			},
-			Referred: t,
+			referred: []interface{}{t},
 		}
 	}
 	arg := args[0]


### PR DESCRIPTION
To DRY things up in the `api/` package, this PR adds a new `Projectable` interface that describes things that go in the SELECT clause of a SELECT statement. In other words, things that can always produce a DerivedColumn and can reference one or more Table or DerivedTable (subquery) elements.

Updates the `api.AggregateFunction` struct first to implement the new `api.Projectable` interface.