### PR TITLE
remove Correlation from ColumnReference

### DIFF
--- a/core/fn/base.go
+++ b/core/fn/base.go
@@ -57,11 +57,6 @@ func (f *BaseFunction) ColumnReference() *grammar.ColumnReference {
 			Identifiers: ids,
 		},
 	}
-	if f.alias != "" {
-		cr.Correlation = &grammar.Correlation{
-			Name: f.alias,
-		}
-	}
 	return cr
 }
 

--- a/core/inspect/predicate_test.go
+++ b/core/inspect/predicate_test.go
@@ -114,9 +114,6 @@ func TestPredicateEqual(t *testing.T) {
 									"author",
 								},
 							},
-							Correlation: &grammar.Correlation{
-								Name: "a",
-							},
 						},
 					},
 				},

--- a/core/meta/column.go
+++ b/core/meta/column.go
@@ -61,11 +61,6 @@ func (c *Column) ColumnReference() *grammar.ColumnReference {
 			Identifiers: []string{c.t.AliasOrName(), c.name},
 		},
 	}
-	if c.alias != "" {
-		cr.Correlation = &grammar.Correlation{
-			Name: c.alias,
-		}
-	}
 	return cr
 }
 
@@ -79,6 +74,9 @@ func (c *Column) DerivedColumn() *grammar.DerivedColumn {
 				},
 			},
 		},
+	}
+	if c.alias != "" {
+		dc.As = &c.alias
 	}
 	return dc
 }

--- a/grammar/column_reference.go
+++ b/grammar/column_reference.go
@@ -13,5 +13,4 @@ package grammar
 type ColumnReference struct {
 	BasicIdentifierChain *IdentifierChain
 	//ModuleIdentifier *ModuleIdentifier
-	Correlation *Correlation
 }

--- a/internal/builder/column_reference.go
+++ b/internal/builder/column_reference.go
@@ -18,8 +18,4 @@ func (b *Builder) doColumnReference(
 	if el.BasicIdentifierChain != nil {
 		b.doIdentifierChain(el.BasicIdentifierChain, qargs, curarg)
 	}
-	if el.Correlation != nil {
-		b.Write(grammar.Symbols[grammar.SYM_AS])
-		b.WriteString(el.Correlation.Name)
-	}
 }


### PR DESCRIPTION
The `<column reference>` SQL grammar element does not have a Correlation field. This was left over from a time when we were incorrectly conflating a `<derived column>` with a `<column reference>`. Removed this vestigial tail...