### PR TITLE
adds start of functional testing framework

### DIFF
--- a/internal/scripts/lib/common.sh
+++ b/internal/scripts/lib/common.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir="$this_dir/.."
+lib_dir="$scripts_dir/lib"
+
+# debug_enabled returns 0 if the DEBUG environs variable is set to anything
+# other than "0", 1 otherwise.
+debug_enabled() {
+  if [ -z "$DEBUG" ]; then
+    return 1
+  fi
+  if [[ "$DEBUG" != "0" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# check_is_installed checks to see if the supplied executable is installed and
+# exits if not. An optional second argument is an extra message to display when
+# the supplied executable is not installed.
+#
+# Usage:
+#
+#   check_is_installed PROGRAM [ MSG ]
+#
+# Example:
+#
+#   check_is_installed kind "You can install kind with the helper scripts/install-kind.sh"
+check_is_installed() {
+  local __name="$1"
+  local __extra_msg="$2"
+  if ! is_installed "$__name"; then
+    echo "FATAL: Missing requirement '$__name'" >&2
+    echo "Please install $__name before running this script." >&2
+    if [[ -n $__extra_msg ]]; then
+      echo "" >&2
+      echo "$__extra_msg" >&2
+      echo "" >&2
+    fi
+    exit 1
+  fi
+}
+
+# is_installed returns 0 if the supplied program is installed on the system,
+# 1 otherwise
+#
+# Usage:
+#
+#   is_installed PROGRAM
+#
+# Example:
+#
+#   if is_installed $PROGRAM; then
+#     echo "$PROGRAM is installed."
+#   fi
+is_installed() {
+  local __name="$1"
+  if command -v "$__name" >/dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/internal/scripts/lib/container.sh
+++ b/internal/scripts/lib/container.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir="$this_dir/.."
+lib_dir="$scripts_dir/lib"
+
+source "$lib_dir/print.sh"
+
+# container::get_ip sets a variable with a supplied name to the IP address of a
+# named container.
+#
+# Usage:
+#
+#   container::get_ip CONTAINER_NAME IP_VAR_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#   IP_VAR_NAME: (required) name for variable to store the IP address in
+#
+# Example:
+#
+#   # Get the IP address of the container named "etcd-testing" and store that
+#   # IP address in a variable named "etcd_container_ip"
+#   container::get_ip "etcd-testing" etcd_container_ip
+#   echo $etcd_container_ip
+container::get_ip() {
+  local __container_name="$1"
+  local __store_result=$2
+  local __sleep_time=0
+  local __found_ip=""
+
+  until [ $__sleep_time -eq 8 ]; do
+    sleep $(( __sleep_time++ ))
+    __found_ip=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$__container_name")
+    if [[ "$__found_ip" != "" ]]; then
+      break
+    fi
+  done
+  eval $__store_result="'$__found_ip'"
+}
+
+# container::is_running Returns 0 if a container with the given name is
+# running, 1 otherwise.
+#
+# Usage:
+#
+#   container::is_running CONTAINER_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#
+# Usage:
+#
+#   if container::is_running "etcd-example"; then
+#     echo "etcd-example container is running."
+#   else
+#     echo "etcd-example container is not running."
+#   fi
+container::is_running() {
+  local __container_name="$1"
+
+  __running=$(
+    docker inspect \
+        --format='{{.State.Running}}' \
+        "$__container_name" 2>/dev/null
+  )
+  if [ $? -eq 1 ]; then
+    return 1
+  fi
+  if [ "$__running" = "true" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# container::exists returns 0 if the container with the given name exists, 1
+# otherwise.
+#
+# Note that a stopped container still exists on the system. So, while
+# container::is_running returns 1 for a stopped container, container::exists
+# will return 0 for a stopped container.
+#
+# Usage:
+#
+#   container::exists CONTAINER_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#
+# Usage:
+#
+#   if container::exists "etcd-example"; then
+#     echo "etcd-example container exists."
+#   else
+#     echo "etcd-example container does not exist."
+#   fi
+container::exists() {
+  local __container_name="$1"
+
+  # Obviously all containers that are running also exist...
+  if container::is_running "$__container_name"; then
+    return 0
+  fi
+
+  __status=$(docker inspect --format='{{.State.Status}}' "$__container_name" 2>/dev/null )
+  if [ $? -eq 1 ]; then
+    return 1
+  fi
+  if [ "$__status" = "created" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# container::stop gracefully stops the container with the given name but does
+# not destroy the container.
+#
+# Usage:
+#
+#   container::stop CONTAINER_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#
+# Usage:
+#
+#   container::stop "etcd-example"
+container::stop() {
+  local __container_name="$1"
+
+  if container::is_running "$__container_name"; then
+    docker stop "$__container_name" --time 2 1>/dev/null
+  fi
+}
+
+# container::destroy destroys the container with the given name.
+#
+# If the container with the given name is active, this function first attempts
+# to gracefully stop the container.
+#
+# Usage:
+#
+#   container::destroy CONTAINER_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#
+# Usage:
+#
+#   container::destroy "etcd-example"
+container::destroy() {
+  local __container_name="$1"
+
+  container::stop "$__container_name"
+  if container::exists "$__container_name"; then
+    docker rm "$__container_name"  1>/dev/null
+  fi
+}
+
+# container::image_exists returns 0 if an image with the given name:tag exists,
+# 1 otherwise.
+#
+# Usage:
+#
+#   container::image_exists CONTAINER_NAME
+#
+#   CONTAINER_NAME: (required) name for the container
+#
+# Usage:
+#
+#   if container::image_exists "etcd-example"; then
+#     echo "etcd-example image exists."
+#   fi
+container::image_exists() {
+  local __image_name_tag="$1"
+
+  docker image inspect "$__image_name_tag" >/dev/null 2>&1
+}

--- a/internal/scripts/lib/mysql.sh
+++ b/internal/scripts/lib/mysql.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+DEFAULT_MYSQL_CONTAINER_NAME="sqlb-test-mysql"
+
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir="$this_dir/.."
+lib_dir="$scripts_dir/lib"
+
+source "$lib_dir/container.sh"
+source "$lib_dir/print.sh"
+
+# mysql::start starts a container (in daemon mode) running mysql
+#
+# Usage:
+#
+#   mysql::start [CONTAINER_NAME] [DATA_DIR] [BIND_ADDRESS]
+#
+#   CONTAINER_NAME: (optional) name for the container
+#     Default: sqlbtestmysql
+#   DATA_DIR: (optional) path to directory to use for mysql state
+#     Default: A tmpdir is created (/tmp/mysql-XXXXXX)
+#   BIND_ADDRESS: (optional) bind address that mysql will use within the
+#   container
+#     Default: 0.0.0.0
+#
+# Usage:
+#
+#   # Start a container called "mysql-example" running mysql using
+#   # /opt/mysql-data as the directory to save mysql's state
+#   mysql::start "mysql-example" /opt/mysql-data
+mysql::start() {
+  local __container_name="${1:-$DEFAULT_MYSQL_CONTAINER_NAME}"
+  local __data_dir="${2:-$(mktemp -d -t mysql-XXXXXX)}"
+  if [ ! -d $__data_dir ]; then
+    echo "ERROR: cannot start mysql container. Supplied data_dir $__data_dir does not exist." >&2
+    return 1
+  fi
+  local __node_addr="${3:-"0.0.0.0"}"
+
+  if container::is_running "$__container_name"; then
+    print::info "mysql container '$__container_name' already running"
+    return 0
+  fi
+
+  print::inline_first "starting mysql container '$__container_name' ..."
+  docker run -d \
+    --rm \
+    -p 33060:3306 \
+    --volume="$__data_dir":/var/lib/mysql \
+    --name "$__container_name" \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+    -e MYSQL_ROOT_HOST="%" \
+    mysql/mysql-server:5.7 \
+    --bind-address "$__node_addr" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    print::ok
+  else
+    echo "failed to start mysql container."
+    return 1
+  fi
+    
+
+  # We need to wait until we see "/usr/sbin/mysqld: ready for connections" in
+  # the docker logs *and* the server was started on port 3306. There are two
+  # times that "mysqld: ready for connections" will appear. The first is when
+  # the server is initially started on port 0 during bootstrapping and the
+  # second is the "normal" mysqld startup process. If we don't do this, we'll
+  # just get connection errors when trying to connect to the server :(
+
+  print::inline_first "waiting for mysql to be ready for connections ..."
+  local __sleep_time=0
+  ready=0
+  until [ $__sleep_time -eq 120 ]; do
+    sleep 4
+    __sleep_time=$(( __sleep_time + 3 ))
+    found=$(docker logs --tail 20 "$__container_name" 2>&1 | grep -A2 "mysqld: ready for connections" | grep "port: 3306")
+    if [ $? -eq 0 ]; then
+      ready=0
+      break
+    else
+      print::inline "."
+    fi
+  done
+
+  if [ $ready -eq 0 ]; then
+    print::ok
+  else
+    print::fail
+    echo "failed to detect mysql ready for connections after 2 minutes."
+    return 1
+  fi
+}
+
+
+# mysql::stop stops the named container running mysql
+#
+# Usage:
+#
+#   mysql::stop [CONTAINER_NAME]
+#
+#   CONTAINER_NAME: (optional) name for the container
+#     Default: sqlbtestmysql
+#
+# Usage:
+#
+#   mysql::stop "mysql-example"
+mysql::stop() {
+  local __container_name="${1:-$DEFAULT_MYSQL_CONTAINER_NAME}"
+  print::inline_first "stopping mysql container '$__container_name' ..."
+  container::stop "$__container_name"
+  print::ok
+}

--- a/internal/scripts/lib/print.sh
+++ b/internal/scripts/lib/print.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir="$this_dir/.."
+lib_dir="$scripts_dir/lib"
+
+source "$lib_dir/common.sh"
+
+default_debug_prefix="[debug] "
+default_info_prefix="[info] "
+
+# print::debug prints out a supplied message if the DEBUG environs variable is
+# set. An optional second argument indicates the "indentation level" for the
+# message.
+print::debug() {
+  if !debug_enabled; then
+    return 0
+  fi
+  local __msg="$1"
+  local __indent_level=${2:-}
+  local __debug_prefix="${DEBUG_PREFIX:-$default_debug_prefix}"
+  _echo_with_indent "$__msg" "$__debug_prefix" no $__indent_level
+}
+
+# print::debug_inline prints out a supplied message with no trailing newline if
+# the DEBUG environs variable is set.
+print::debug_inline() {
+  if !debug_enabled; then
+    return 0
+  fi
+  local __msg="$1"
+  print::inline "$__msg"
+}
+
+# print::info prints out a supplied message. An optional second argument
+# indicates the "indentation level" for the message.
+print::info() {
+  local __msg="$1"
+  local __indent_level=${2:-}
+  local __info_prefix="${INFO_PREFIX:-$default_info_prefix}"
+  _echo_with_indent "$__msg" "$(_info_prefix)" no $__indent_level
+}
+
+# print::inline_first prints out a supplied message with no trailing newline
+# after prepending the info-level prefix.
+print::inline_first() {
+  local __msg="$1"
+  print::inline "$(_info_prefix)$__msg"
+}
+
+# print::debug_inline_first prints out a supplied message with no trailing
+# newline after prepending the debug-level prefix if the DEBUG environs
+# variable is set.
+print::debug_inline_first() {
+  local __msg="$1"
+  print::debug_inline "$(_debug_prefix)$__msg"
+}
+
+# print::inline prints out a supplied message with no trailing newline.
+print::inline() {
+  local __msg="$1"
+  echo -n "$__msg"
+}
+
+# print::ok prints "ok." and a newline.
+print::ok() {
+  echo " ok."
+}
+
+# print::fail prints "fail." and a newline.
+print::fail() {
+  echo " fail."
+}
+
+# print::debug_ok prints "ok." and a newline if debugging is on.
+print::debug_ok() {
+  if !debug_enabled; then
+    return 0
+  fi
+  echo " ok."
+}
+
+# print::debug_fail prints "fail." and a newline if debugging is on.
+print::debug_fail() {
+  if !debug_enabled; then
+    return 0
+  fi
+  echo " fail."
+}
+
+_echo_with_indent() {
+  local __msg="$1"
+  local __prefix="$2"
+  local __indent_level=${4:-}
+  __indent=""
+  if [ -n "$__indent_level" ]; then
+    __indent="$( for _ in $( seq 0 "$__indent_level" ); do printf " "; done )"
+  fi
+  echo "$__prefix$__indent$__msg"
+}
+
+_debug_prefix() {
+  local __debug_prefix="${DEBUG_PREFIX:-$default_debug_prefix}"
+  echo "$(_timestamp) $__debug_prefix"
+}
+
+_info_prefix() {
+  local __info_prefix="${INFO_PREFIX:-$default_info_prefix}"
+  echo "$(_timestamp) $__info_prefix"
+}
+
+_timestamp() {
+  date '+%H:%M:%S.%3N'
+}

--- a/internal/scripts/mysql_start.sh
+++ b/internal/scripts/mysql_start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+DEBUG=${DEBUG:-0}
+scripts_dir=$(cd $(dirname "$0") && pwd)
+lib_dir="$scripts_dir/lib"
+
+source $lib_dir/common.sh
+
+check_is_installed docker
+
+source $lib_dir/container.sh
+source $lib_dir/mysql.sh
+
+if debug_enabled; then
+    set -o xtrace
+fi
+
+container_name=${1:-${MYSQL_CONTAINER_NAME:-"$DEFAULT_MYSQL_CONTAINER_NAME"}}
+
+mysql::start "$container_name"
+
+if container::get_ip "$container_name" container_ip; then
+    print::info "mysql running in container '${container_name}' at ${container_ip}:3306."
+else
+    echo "failed to determine mysql container's IP address."
+    exit 1
+fi

--- a/internal/scripts/reset.sh
+++ b/internal/scripts/reset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Used for "resetting" a functional testing environment back to a clean start
+# state.
+#
+# This script stops the following containers if they are running:
+#  * sqlb-test-mysql
+#
+# And then proceeds to clear out the SQL database. We do not attempt to
+# stop/start the sqlb-test-mysql container because this container takes a
+# stupid long time to start up due to the init scripts used by the MySQL Docker
+# container. Instead, we just DROP and re-CREATE the database.
+
+DEBUG=${DEBUG:-0}
+
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir="$this_dir"
+lib_dir="$scripts_dir/lib"
+
+default_dbname="sqlbtest"
+
+source "$lib_dir/common.sh"
+
+check_is_installed docker
+check_is_installed mysql
+
+source "$lib_dir/container.sh"
+source "$lib_dir/mysql.sh"
+
+dbname="${TESTDB_NAME:-$default_dbname}"
+mysql_container_name=${MYSQL_CONTAINER_NAME:-"$DEFAULT_MYSQL_CONTAINER_NAME"}
+
+if ! container::is_running "$mysql_container_name"; then
+  $scripts_dir/mysql_start.sh "$mysql_container_name"
+else
+  print::info "mysql container '$mysql_container_name' already running"
+fi
+
+if ! container::get_ip "$mysql_container_name" mysql_container_ip; then
+  echo "ERROR: could not get IP for mysql container"
+  exit 1
+fi
+
+print::inline_first "Dropping mysql test $dbname database ... "
+mysql -uroot -P3306 -h$mysql_container_ip -e "DROP DATABASE IF EXISTS $dbname;"
+print::ok
+
+print::inline_first "Creating mysql test $dbname database ... "
+tmpsql_path=$(mktemp)
+dbname=$dbname envsubst < $scripts_dir/sqlbtest_mysql.sql > $tmpsql_path
+mysql -uroot -P3306 -h$mysql_container_ip < $tmpsql_path
+print::ok

--- a/internal/scripts/sqlbtest_mysql.sql
+++ b/internal/scripts/sqlbtest_mysql.sql
@@ -1,0 +1,46 @@
+CREATE DATABASE IF NOT EXISTS ${dbname};
+
+USE ${dbname};
+
+CREATE TABLE article_states (
+  id INT NOT NULL
+, name VARCHAR(20) NOT NULL
+, PRIMARY KEY (id)
+);
+
+INSERT INTO article_states (id, name) VALUES
+  (1, "draft")
+, (2, "published")
+, (3, "archived")
+;
+
+CREATE TABLE users (
+  id INT NOT NULL
+, name VARCHAR(100) NOT NULL
+, created_on DATETIME NOT NULL
+, PRIMARY KEY (id)
+, UNIQUE INDEX (name)
+);
+
+INSERT INTO users (id, name, created_on) VALUES
+  (1, "Alice", "2018-01-18")
+, (2, "Bob", "2018-02-09")
+, (3, "Charlie", "2019-12-11")
+;
+
+CREATE TABLE articles (
+  id INT NOT NULL
+, title VARCHAR(200) NOT NULL
+, author INT NOT NULL
+, state INT NOT NULL
+, created_on DATETIME NOT NULL
+, PRIMARY KEY (id)
+, INDEX ix_title (title)
+, FOREIGN KEY fk_users (author) REFERENCES users (id)
+);
+
+INSERT INTO articles (id, title, author, state, created_on) VALUES
+  (1, "Alice's list of grievances", 1, 2, "2018-01-19")
+, (2, "Bob's list of accomplishments", 2, 1, "2018-06-19")
+, (3, "Charlie's list of statements", 3, 3, "2019-12-13")
+;


### PR DESCRIPTION
Adds Bash scripts and SQL schema for MySQL to the internal/scripts directory in preparation for functional testing.

The `internal/scripts/reset.sh` script may be executed to reset the MySQL database inside a Docker container that we will use as a test bed for sqlb:

```
➜  sqlb git:(func-test) ✗ ./internal/scripts/reset.sh
19:59:40.269 [info] starting mysql container 'sqlb-test-mysql' ... ok.
19:59:40.465 [info] waiting for mysql to be ready for connections .... ok.
19:59:48.551 [info] mysql running in container 'sqlb-test-mysql' at 172.17.0.2:3306.
19:59:48.594 [info] Dropping mysql test sqlbtest database ...  ok.
19:59:48.657 [info] Creating mysql test sqlbtest database ...  ok.
➜  sqlb git:(func-test) ✗ mysql -uroot -P3306 -h172.17.0.2 -D sqlbtest -e "SHOW TABLES"
+--------------------+
| Tables_in_sqlbtest |
+--------------------+
| article_states     |
| articles           |
| users              |
+--------------------+
```