### PR TITLE
add func testing Github Action workflow

### DIFF
--- a/.github/workflows/test-func.yml
+++ b/.github/workflows/test-func.yml
@@ -1,0 +1,43 @@
+name: test-func
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+# see: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+jobs:
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+    env:
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_ROOT_PASSWORD: root
+    steps:
+     - name: harden runner
+       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+       with:
+         egress-policy: block
+         allowed-endpoints: >
+           github.com:443
+           api.github.com:443
+           proxy.github.com:443
+           proxy.golang.org:443
+           raw.githubusercontent.com:443
+           objects.githubusercontent.com:443
+           proxy.golang.org:443
+     - name: checkout code
+       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+     - name: setup go
+       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+       with:
+         go-version: "1.21"
+     - name: start the MySQL service
+       run: sudo systemctl start mysql.service
+     - name: reset test databases
+       run: ./internal/testing/scripts/reset.sh
+     - name: run functional tests
+       run: cd internal/testing && go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test-unit:
 .PHONY: test-func test-func-reset
 test-func: test-func-reset
 	@cd internal/testing; \
-	SQLBTEST_MYSQL_IP="$(shell ./internal/testing/scripts/mysql_get_ip.sh $$MYSQL_CONTAINER_NAME)" go test -v ./...
+	MYSQL_HOST="$(shell ./internal/testing/scripts/mysql_get_ip.sh $$MYSQL_CONTAINER_NAME)" go test -v ./...
 
 test-func-reset:
 	@./internal/testing/scripts/reset.sh

--- a/internal/testing/reflect_test.go
+++ b/internal/testing/reflect_test.go
@@ -20,18 +20,20 @@ import (
 )
 
 const (
-	envVarMySQLContainerIP = "SQLBTEST_MYSQL_IP"
+	envVarMySQLHost         = "MYSQL_HOST"
+	envVarMySQLRootPassword = "MYSQL_ROOT_PASSWORD"
 )
 
 func skipIfNoMySQL(t *testing.T) {
-	if _, ok := os.LookupEnv(envVarMySQLContainerIP); !ok {
+	if _, ok := os.LookupEnv(envVarMySQLHost); !ok {
 		t.Skip("No MySQL container found.")
 	}
 }
 
 func getMySQLDSN() string {
-	containerIP := os.Getenv(envVarMySQLContainerIP)
-	return fmt.Sprintf("root@(%s:3306)/sqlbtest", containerIP)
+	host := os.Getenv(envVarMySQLHost)
+	pwd := os.Getenv(envVarMySQLRootPassword)
+	return fmt.Sprintf("root:%s@tcp(%s:3306)/sqlbtest", pwd, host)
 }
 
 func TestReflectMySQL(t *testing.T) {


### PR DESCRIPTION
Modifies the internal/testing/scripts/reset.sh script to optionally supply a MYSQL_HOST and MYSQL_ROOT_PASSWORD environs variable instead of starting up a Docker container running MySQL. Adds a new functional testing Github Actions workflow that runs the reset script and the functional Go tests that utilize the test database.